### PR TITLE
Feat/4 oauth2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-log4j2'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/com/oinzo/somoim/common/exception/ErrorCode.java
+++ b/src/main/java/com/oinzo/somoim/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 	/* 400 Bad Request */
 	INVALID_TOKEN(HttpStatus.BAD_REQUEST, 40002, "잘못된 토큰입니다."),
+	INVALID_KAKAO_CODE(HttpStatus.BAD_REQUEST, 40003, "올바르지 않은 카카오 인가 코드입니다."),
 
 	/* 401 Unauthorized */
 	ACCESS_TOKEN_OMISSION(HttpStatus.UNAUTHORIZED, 40101, "인증 정보(액세스 토큰)가 누락되었습니다."),
@@ -21,7 +22,10 @@ public enum ErrorCode {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, 40401, "사용자를 찾을 수 없습니다."),
 
 	/* 500 Internal Server Error */
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "예상치 못한 오류가 발생했습니다.");
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "예상치 못한 오류가 발생했습니다."),
+	INVALID_KAKAO_REDIRECT_URI(HttpStatus.INTERNAL_SERVER_ERROR, 50001, "리다이렉트 주소가 일치하지 않습니다. 카카오 인가 코드 요청 시 사용한 리다이렉트 주소를 백엔드 담당자에게 알려주세요."),
+	KAKAO_ACCESS_TOKEN_REQUEST_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50002, "인가 코드를 통해 카카오 액세스 토큰을 발급받는 중에 문제가 발생했습니다."),
+	KAKAO_USERINFO_REQUEST_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5003, "액세스 토큰을 통해 카카오 사용자 정보를 조회하는 과정에서 문제가 발생했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final int code;

--- a/src/main/java/com/oinzo/somoim/common/exception/ErrorCode.java
+++ b/src/main/java/com/oinzo/somoim/common/exception/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "예상치 못한 오류가 발생했습니다."),
 	INVALID_KAKAO_REDIRECT_URI(HttpStatus.INTERNAL_SERVER_ERROR, 50001, "리다이렉트 주소가 일치하지 않습니다. 카카오 인가 코드 요청 시 사용한 리다이렉트 주소를 백엔드 담당자에게 알려주세요."),
 	KAKAO_ACCESS_TOKEN_REQUEST_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50002, "인가 코드를 통해 카카오 액세스 토큰을 발급받는 중에 문제가 발생했습니다."),
-	KAKAO_USERINFO_REQUEST_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5003, "액세스 토큰을 통해 카카오 사용자 정보를 조회하는 과정에서 문제가 발생했습니다.");
+	KAKAO_USERINFO_REQUEST_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50003, "액세스 토큰을 통해 카카오 사용자 정보를 조회하는 과정에서 문제가 발생했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final int code;

--- a/src/main/java/com/oinzo/somoim/config/RestTemplateConfiguration.java
+++ b/src/main/java/com/oinzo/somoim/config/RestTemplateConfiguration.java
@@ -1,0 +1,15 @@
+package com.oinzo.somoim.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfiguration {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+
+}

--- a/src/main/java/com/oinzo/somoim/config/SecurityConfiguration.java
+++ b/src/main/java/com/oinzo/somoim/config/SecurityConfiguration.java
@@ -29,6 +29,11 @@ public class SecurityConfiguration {
 			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 
 			.and()
+			.authorizeRequests()
+			.antMatchers("/users/oauth/**").permitAll()
+			.anyRequest().hasRole("USER")
+
+			.and()
 			.exceptionHandling()
 			.authenticationEntryPoint(new JwtAuthenticationEntryPoint())
 			.accessDeniedHandler(new JwtAccessDeniedHandler())

--- a/src/main/java/com/oinzo/somoim/controller/OAuth2Controller.java
+++ b/src/main/java/com/oinzo/somoim/controller/OAuth2Controller.java
@@ -3,6 +3,7 @@ package com.oinzo.somoim.controller;
 import com.oinzo.somoim.common.jwt.JwtProvider;
 import com.oinzo.somoim.common.jwt.TokenDto;
 import com.oinzo.somoim.common.jwt.TokenService;
+import com.oinzo.somoim.controller.dto.GoogleLoginRequest;
 import com.oinzo.somoim.controller.dto.TokenResponse;
 import com.oinzo.somoim.controller.dto.kakaoLoginRequest;
 import com.oinzo.somoim.domain.user.service.OAuth2Service;
@@ -34,4 +35,14 @@ public class OAuth2Controller {
 		return TokenResponse.from(tokenDto);
 	}
 
+	@PostMapping("/google")
+	public TokenResponse googleLogin(
+		@RequestBody @Valid GoogleLoginRequest request,
+		HttpServletResponse response) {
+		Long userId = oAuth2Service.googleLogin(request.getCode());
+		TokenDto tokenDto = jwtProvider.generateAccessTokenAndRefreshToken(userId);
+		String refreshToken = tokenDto.getRefreshToken();
+		tokenService.setRefreshTokenCookie(refreshToken, response);
+		return TokenResponse.from(tokenDto);
+	}
 }

--- a/src/main/java/com/oinzo/somoim/controller/OAuth2Controller.java
+++ b/src/main/java/com/oinzo/somoim/controller/OAuth2Controller.java
@@ -1,0 +1,37 @@
+package com.oinzo.somoim.controller;
+
+import com.oinzo.somoim.common.jwt.JwtProvider;
+import com.oinzo.somoim.common.jwt.TokenDto;
+import com.oinzo.somoim.common.jwt.TokenService;
+import com.oinzo.somoim.controller.dto.TokenResponse;
+import com.oinzo.somoim.controller.dto.kakaoLoginRequest;
+import com.oinzo.somoim.domain.user.service.OAuth2Service;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/users/oauth")
+public class OAuth2Controller {
+
+	private final OAuth2Service oAuth2Service;
+	private final JwtProvider jwtProvider;
+	private final TokenService tokenService;
+
+	@PostMapping("/kakao")
+	public TokenResponse kakaoLogin(
+		@RequestBody @Valid kakaoLoginRequest request,
+		HttpServletResponse response) {
+		Long userId = oAuth2Service.kakaoLogin(request.getCode());
+		TokenDto tokenDto = jwtProvider.generateAccessTokenAndRefreshToken(userId);
+		String refreshToken = tokenDto.getRefreshToken();
+		tokenService.setRefreshTokenCookie(refreshToken, response);
+		return TokenResponse.from(tokenDto);
+	}
+
+}

--- a/src/main/java/com/oinzo/somoim/controller/dto/GoogleLoginRequest.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/GoogleLoginRequest.java
@@ -1,0 +1,17 @@
+package com.oinzo.somoim.controller.dto;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GoogleLoginRequest {
+
+	@NotBlank
+	private String code;
+
+}

--- a/src/main/java/com/oinzo/somoim/controller/dto/kakaoLoginRequest.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/kakaoLoginRequest.java
@@ -1,0 +1,17 @@
+package com.oinzo.somoim.controller.dto;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class kakaoLoginRequest {
+
+	@NotBlank
+	private String code;
+
+}

--- a/src/main/java/com/oinzo/somoim/domain/user/dto/GoogleUserInfoDto.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/dto/GoogleUserInfoDto.java
@@ -1,0 +1,19 @@
+package com.oinzo.somoim.domain.user.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GoogleUserInfoDto {
+
+	private String googleId;
+	private String name;
+	private String profileUrl;
+
+}

--- a/src/main/java/com/oinzo/somoim/domain/user/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/dto/KakaoUserInfoDto.java
@@ -1,0 +1,21 @@
+package com.oinzo.somoim.domain.user.dto;
+
+import com.oinzo.somoim.common.type.Gender;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoUserInfoDto {
+
+	private long kakaoId;
+	private String profileUrl;
+	private Gender gender;
+	private String birthday;
+
+}

--- a/src/main/java/com/oinzo/somoim/domain/user/entity/User.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package com.oinzo.somoim.domain.user.entity;
 import com.oinzo.somoim.common.entity.BaseEntity;
 import com.oinzo.somoim.common.type.Gender;
 import com.oinzo.somoim.common.type.SocialType;
+import com.oinzo.somoim.domain.user.dto.KakaoUserInfoDto;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -40,4 +41,14 @@ public class User extends BaseEntity {
 	@Enumerated(value = EnumType.STRING)
 	private SocialType socialType;
 	private String socialId;
+
+	public static User from(KakaoUserInfoDto kakaoUserInfoDto) {
+		return User.builder()
+			.socialType(SocialType.KAKAO)
+			.socialId(String.valueOf(kakaoUserInfoDto.getKakaoId()))
+//            .birth(kakaoUserInfoDto.getBirthday())
+			.gender(kakaoUserInfoDto.getGender())
+			.profileUrl(kakaoUserInfoDto.getProfileUrl())
+			.build();
+	}
 }

--- a/src/main/java/com/oinzo/somoim/domain/user/entity/User.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package com.oinzo.somoim.domain.user.entity;
 import com.oinzo.somoim.common.entity.BaseEntity;
 import com.oinzo.somoim.common.type.Gender;
 import com.oinzo.somoim.common.type.SocialType;
+import com.oinzo.somoim.domain.user.dto.GoogleUserInfoDto;
 import com.oinzo.somoim.domain.user.dto.KakaoUserInfoDto;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -49,6 +50,15 @@ public class User extends BaseEntity {
 //            .birth(kakaoUserInfoDto.getBirthday())
 			.gender(kakaoUserInfoDto.getGender())
 			.profileUrl(kakaoUserInfoDto.getProfileUrl())
+			.build();
+	}
+
+	public static User from(GoogleUserInfoDto googleUserInfoDto) {
+		return User.builder()
+			.socialType(SocialType.GOOGLE)
+			.socialId(googleUserInfoDto.getGoogleId())
+			.name(googleUserInfoDto.getName())
+			.profileUrl(googleUserInfoDto.getProfileUrl())
 			.build();
 	}
 }

--- a/src/main/java/com/oinzo/somoim/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/repository/UserRepository.java
@@ -1,10 +1,14 @@
 package com.oinzo.somoim.domain.user.repository;
 
+import com.oinzo.somoim.common.type.SocialType;
 import com.oinzo.somoim.domain.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+	Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String providerId);
 
 }

--- a/src/main/java/com/oinzo/somoim/domain/user/service/GoogleOAuth2Service.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/service/GoogleOAuth2Service.java
@@ -1,0 +1,121 @@
+package com.oinzo.somoim.domain.user.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.oinzo.somoim.common.exception.BaseException;
+import com.oinzo.somoim.common.exception.ErrorCode;
+import com.oinzo.somoim.domain.user.dto.GoogleUserInfoDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+public class GoogleOAuth2Service {
+
+	@Value("${oauth2.google.client-id}")
+	private String GOOGLE_CLIENT_ID;
+	@Value("${oauth2.google.client-secret}")
+	private String GOOGLE_CLIENT_SECRET;
+	@Value("${service.front.domain}")
+	private String FRONT_DOMAIN;
+
+	private final RestTemplate restTemplate;
+	private final ObjectMapper objectMapper;
+
+	public GoogleOAuth2Service(RestTemplate restTemplate) {
+		this.restTemplate = restTemplate;
+		this.objectMapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+	}
+
+	public String getAccessToken(String code) {
+		String accessTokenBody = requestAccessToken(code);
+		return parseAccessToken(accessTokenBody);
+	}
+
+	public GoogleUserInfoDto getUserInfo(String accessToken) {
+		String userInfoBody = requestUserInfo(accessToken);
+		return parseUserInfo(userInfoBody);
+	}
+
+	private String requestAccessToken(String code) {
+		String GOOGLE_ACCESS_TOKEN_REQUEST_URL = "https://oauth2.googleapis.com/token";
+		String GOOGLE_CODE_REDIRECT_URI = FRONT_DOMAIN + "/auth/google/callback";	// 인가코드 받았던 리다이렉트 주소
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded;charset=utf-8");
+
+		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+		body.add("grant_type", "authorization_code");
+		body.add("client_id", GOOGLE_CLIENT_ID);
+		body.add("client_secret", GOOGLE_CLIENT_SECRET);
+		body.add("redirect_uri", GOOGLE_CODE_REDIRECT_URI);
+		body.add("code", code);
+
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+		ResponseEntity<String> response = restTemplate.exchange(
+			GOOGLE_ACCESS_TOKEN_REQUEST_URL,
+			HttpMethod.POST,
+			request,
+			String.class
+		);
+
+		return response.getBody();
+	}
+
+	private String parseAccessToken(String accessTokenResponseBody) {
+		try {
+			JsonNode jsonNode = objectMapper.readTree(accessTokenResponseBody);
+			return jsonNode.get("access_token").asText();
+		} catch (JsonProcessingException e) {
+			log.error(e.getMessage());
+			throw new BaseException(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+		}
+	}
+
+	private String requestUserInfo(String accessToken) {
+		String GOOGLE_USERINFO_REQUEST_URL = "https://www.googleapis.com/oauth2/v1/userinfo";
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+		ResponseEntity<String> response = restTemplate.exchange(
+			GOOGLE_USERINFO_REQUEST_URL,
+			HttpMethod.GET,
+			request,
+			String.class
+		);
+
+		return response.getBody();
+	}
+
+	private GoogleUserInfoDto parseUserInfo(String responseBody) {
+		try {
+			JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+			String id = jsonNode.get("id").asText();
+
+			String name = jsonNode.get("name").asText();
+			String profileUrl = jsonNode.get("picture").asText();
+
+			return GoogleUserInfoDto.builder()
+				.googleId(id)
+				.name(name)
+				.profileUrl(profileUrl)
+				.build();
+		} catch (JsonProcessingException e) {
+			log.error(e.getMessage());
+			throw new BaseException(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/oinzo/somoim/domain/user/service/KakaoOAuth2Service.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/service/KakaoOAuth2Service.java
@@ -1,0 +1,180 @@
+package com.oinzo.somoim.domain.user.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.oinzo.somoim.common.exception.BaseException;
+import com.oinzo.somoim.common.exception.ErrorCode;
+import com.oinzo.somoim.common.type.Gender;
+import com.oinzo.somoim.domain.user.dto.KakaoUserInfoDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+public class KakaoOAuth2Service {
+
+	@Value("${oauth2.kakao.client-id}")
+	private String KAKAO_CLIENT_ID;
+	@Value("${service.front.domain}")
+	private String FRONT_DOMAIN;
+
+	private final RestTemplate restTemplate;
+	private final ObjectMapper objectMapper;
+
+	public KakaoOAuth2Service(RestTemplate restTemplate) {
+		this.restTemplate = restTemplate;
+		this.objectMapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+	}
+
+	public String getAccessToken(String code) {
+		String accessTokenResponseBody = requestAccessToken(code);
+		return parseAccessToken(accessTokenResponseBody);
+	}
+
+	public KakaoUserInfoDto getUserInfo(String accessToken) {
+		String userInfoResponseBody = requestUserInfo(accessToken);
+		return parseUserInfo(userInfoResponseBody);
+	}
+
+	private String requestAccessToken(String code) {
+		String KAKAO_ACCESS_TOKEN_REQUEST_URL = "https://kauth.kakao.com/oauth/token";
+		String KAKAO_CODE_REDIRECT_URI = FRONT_DOMAIN + "/auth/kakao/callback";	// 인가코드 받았던 리다이렉트 주소
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded;charset=utf-8");
+
+		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+		body.add("grant_type", "authorization_code");
+		body.add("client_id", KAKAO_CLIENT_ID);
+		body.add("redirect_uri", KAKAO_CODE_REDIRECT_URI);
+		body.add("code", code);
+
+		try {
+			HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+			ResponseEntity<String> response = restTemplate.exchange(
+				KAKAO_ACCESS_TOKEN_REQUEST_URL,
+				HttpMethod.POST,
+				request,
+				String.class
+			);
+			return response.getBody();
+		} catch (HttpClientErrorException | HttpServerErrorException e) {
+			handleAccessTokenRequestError(e);
+			return "";	// handleAccessTokenRequestError()에서 모두 예외를 던지므로 여기까지 올 일 없음
+		}
+	}
+
+	private void handleAccessTokenRequestError(HttpStatusCodeException httpStatusCodeException) {
+		try {
+			JsonNode jsonNode = objectMapper.readTree(httpStatusCodeException.getResponseBodyAsString());
+
+			String errorCode = jsonNode.get("error_code").asText();
+			String errorDescription = jsonNode.get("error_description").asText();
+			log.error(errorCode + ": " + errorDescription);
+
+			if (errorCode.equals("KOE320")) {    // 올바르지 않은 인가 코드
+				throw new BaseException(ErrorCode.INVALID_KAKAO_CODE, errorDescription);
+			} else if (errorCode.equals("KOE303")) {    // redirect uri 불일치
+				throw new BaseException(ErrorCode.INVALID_KAKAO_REDIRECT_URI, errorDescription);
+			} else {
+				throw new BaseException(ErrorCode.KAKAO_ACCESS_TOKEN_REQUEST_ERROR, errorDescription);
+			}
+		} catch (JsonProcessingException e) {
+			log.error(e.getMessage());
+			throw new BaseException(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+		}
+	}
+
+	private String parseAccessToken(String accessTokenResponseBody) {
+		try {
+			JsonNode jsonNode = objectMapper.readTree(accessTokenResponseBody);
+			return jsonNode.get("access_token").asText();
+		} catch (JsonProcessingException e) {
+			log.error(e.getMessage());
+			throw new BaseException(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+		}
+	}
+
+	private String requestUserInfo(String accessToken) {
+		String KAKAO_USERINFO_REQUEST_URL = "https://kapi.kakao.com/v2/user/me";
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+		headers.add(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded;charset=utf-8");
+
+		try {
+			HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+			ResponseEntity<String> response = restTemplate.exchange(
+				KAKAO_USERINFO_REQUEST_URL,
+				HttpMethod.POST,
+				request,
+				String.class
+			);
+			return response.getBody();
+		} catch (HttpClientErrorException | HttpServerErrorException e) {
+			handleUserInfoRequestError(e);
+			return "";	// handleUserInfoRequestError()에서 모두 예외를 던지므로 여기까지 올 일 없음
+		}
+	}
+
+	private void handleUserInfoRequestError(HttpStatusCodeException httpStatusCodeException) {
+		try {
+			JsonNode jsonNode = objectMapper.readTree(httpStatusCodeException.getResponseBodyAsString());
+
+			String errorCode = jsonNode.get("error_code").asText();
+			String errorDescription = jsonNode.get("error_description").asText();
+			log.error(errorCode + ": " + errorDescription);
+
+			throw new BaseException(ErrorCode.KAKAO_USERINFO_REQUEST_ERROR, errorDescription);
+		} catch (JsonProcessingException e) {
+			log.error(e.getMessage());
+			throw new BaseException(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+		}
+	}
+
+	private KakaoUserInfoDto parseUserInfo(String responseBody) {
+		try {
+			JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+			long id = jsonNode.get("id").asLong();
+
+			JsonNode kakaoAccountNode = jsonNode.get("kakao_account");
+			String profileUrl = null;
+			if (kakaoAccountNode.has("profile") && kakaoAccountNode.get("profile").has("profile_image_url")) {
+				profileUrl = kakaoAccountNode.get("profile").get("profile_image_url").asText();
+			}
+			String gender = null;
+			if (kakaoAccountNode.has("gender")) {
+				gender = kakaoAccountNode.get("gender").asText();
+			}
+			String birthday = null;
+			if (kakaoAccountNode.has("birthday")) {
+				birthday = kakaoAccountNode.get("birthday").asText();
+			}
+
+			return KakaoUserInfoDto.builder()
+				.kakaoId(id)
+				.profileUrl(profileUrl)
+				.gender(gender == null ? null : gender.equals("male") ? Gender.MALE : Gender.FEMALE)    // Gender enum으로 변경
+				.birthday(birthday)
+				.build();
+		} catch (JsonProcessingException e) {
+			log.error(e.getMessage());
+			throw new BaseException(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+		}
+	}
+
+}

--- a/src/main/java/com/oinzo/somoim/domain/user/service/OAuth2Service.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/service/OAuth2Service.java
@@ -1,0 +1,28 @@
+package com.oinzo.somoim.domain.user.service;
+
+import com.oinzo.somoim.common.type.SocialType;
+import com.oinzo.somoim.domain.user.dto.KakaoUserInfoDto;
+import com.oinzo.somoim.domain.user.entity.User;
+import com.oinzo.somoim.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class OAuth2Service {
+
+	private final KakaoOAuth2Service kakaoOAuth2Service;
+	private final UserRepository userRepository;
+
+	public Long kakaoLogin(String code) {
+		String accessToken = kakaoOAuth2Service.getAccessToken(code);
+		KakaoUserInfoDto kakaoUserInfo = kakaoOAuth2Service.getUserInfo(accessToken);
+
+		long kakaoId = kakaoUserInfo.getKakaoId();
+		User user = userRepository.findBySocialTypeAndSocialId(
+			SocialType.KAKAO,
+			String.valueOf(kakaoId))
+			.orElseGet(() -> userRepository.save(User.from(kakaoUserInfo)));
+		return user.getId();
+	}
+}

--- a/src/main/java/com/oinzo/somoim/domain/user/service/OAuth2Service.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/service/OAuth2Service.java
@@ -1,6 +1,7 @@
 package com.oinzo.somoim.domain.user.service;
 
 import com.oinzo.somoim.common.type.SocialType;
+import com.oinzo.somoim.domain.user.dto.GoogleUserInfoDto;
 import com.oinzo.somoim.domain.user.dto.KakaoUserInfoDto;
 import com.oinzo.somoim.domain.user.entity.User;
 import com.oinzo.somoim.domain.user.repository.UserRepository;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 public class OAuth2Service {
 
 	private final KakaoOAuth2Service kakaoOAuth2Service;
+	private final GoogleOAuth2Service googleOAuth2Service;
 	private final UserRepository userRepository;
 
 	public Long kakaoLogin(String code) {
@@ -19,10 +21,18 @@ public class OAuth2Service {
 		KakaoUserInfoDto kakaoUserInfo = kakaoOAuth2Service.getUserInfo(accessToken);
 
 		long kakaoId = kakaoUserInfo.getKakaoId();
-		User user = userRepository.findBySocialTypeAndSocialId(
-			SocialType.KAKAO,
-			String.valueOf(kakaoId))
+		User user = userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, String.valueOf(kakaoId))
 			.orElseGet(() -> userRepository.save(User.from(kakaoUserInfo)));
+		return user.getId();
+	}
+
+	public Long googleLogin(String code) {
+		String accessToken = googleOAuth2Service.getAccessToken(code);
+		GoogleUserInfoDto googleUserInfoDto = googleOAuth2Service.getUserInfo(accessToken);
+
+		String googleId = googleUserInfoDto.getGoogleId();
+		User user = userRepository.findBySocialTypeAndSocialId(SocialType.GOOGLE, googleId)
+			.orElseGet(() -> userRepository.save(User.from(googleUserInfoDto)));
 		return user.getId();
 	}
 }


### PR DESCRIPTION
## 구현 내용
카카오, 구글 소셜로그인을 구현했습니다.
인가 코드를 받으면 소셜 플랫폼에 액세스 토큰을 요청하고 그 토큰을 통해 사용자 정보를 가져옵니다.
DB에 저장되어있지 않다면 DB에 저장한 후 user Id로 액세스 토큰과 리프레시 토큰을 생성합니다.
토큰 정보는 쿠키와 body에 담아 클라이언트에 전달합니다.

현재 `Rest Template`으로 외부 API를 요청하고 있지만, 추후에 더 간편하고 많이 사용하는 `Feign` 라이브러리로 바꿀 예정입니다. (다른 API 개발하는 것이 더 시급하기 때문에 뒤로 미뤘습니다.)
<br>

## 관련 이슈
- #4