### PR TITLE
Feat/2 club cr

### DIFF
--- a/src/main/java/com/oinzo/somoim/common/exception/ErrorCode.java
+++ b/src/main/java/com/oinzo/somoim/common/exception/ErrorCode.java
@@ -12,8 +12,7 @@ public enum ErrorCode {
 	NO_SEARCH_NAME(HttpStatus.NOT_FOUND, 10001, "검색 키워드를 입력해주십시오."),
 
 	NO_DATA_FOUND(HttpStatus.NOT_FOUND, 40001, "해당하는 데이터를 찾을 수 없습니다."),
-	WRONG_CLUB(HttpStatus.NOT_FOUND, 40002, "해당하는 클럽을 찾을 수 없습니다."),
-
+	WRONG_CLUB(HttpStatus.NOT_FOUND, 40003, "해당하는 클럽을 찾을 수 없습니다."),
 	WRONG_FAVORITE(HttpStatus.NOT_FOUND, 40005, "해당하는 관심사를 찾을 수 없습니다."),
 	/* 500 Internal Server Error */
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "예상치 못한 오류가 발생했습니다.");

--- a/src/main/java/com/oinzo/somoim/common/exception/ErrorCode.java
+++ b/src/main/java/com/oinzo/somoim/common/exception/ErrorCode.java
@@ -8,9 +8,13 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-	/* 400 Database Error */
+	/* 100 Request Error */
+	NO_SEARCH_NAME(HttpStatus.NOT_FOUND, 10001, "검색 키워드를 입력해주십시오."),
+
 	NO_DATA_FOUND(HttpStatus.NOT_FOUND, 40001, "해당하는 데이터를 찾을 수 없습니다."),
 	WRONG_CLUB(HttpStatus.NOT_FOUND, 40002, "해당하는 클럽을 찾을 수 없습니다."),
+
+	WRONG_FAVORITE(HttpStatus.NOT_FOUND, 40005, "해당하는 관심사를 찾을 수 없습니다."),
 	/* 500 Internal Server Error */
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "예상치 못한 오류가 발생했습니다.");
 

--- a/src/main/java/com/oinzo/somoim/common/exception/ErrorCode.java
+++ b/src/main/java/com/oinzo/somoim/common/exception/ErrorCode.java
@@ -7,6 +7,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+
+	/* 400 Database Error */
+	NO_DATA_FOUND(HttpStatus.NOT_FOUND, 40001, "해당하는 데이터를 찾을 수 없습니다."),
+	WRONG_CLUB(HttpStatus.NOT_FOUND, 40002, "해당하는 클럽을 찾을 수 없습니다."),
 	/* 500 Internal Server Error */
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "예상치 못한 오류가 발생했습니다.");
 

--- a/src/main/java/com/oinzo/somoim/common/type/Favorite.java
+++ b/src/main/java/com/oinzo/somoim/common/type/Favorite.java
@@ -1,7 +1,8 @@
 package com.oinzo.somoim.common.type;
 
-public enum favorite {
+public enum Favorite {
     SPORTS,
     GAME,
-    TRIP
+    TRIP;
+
 }

--- a/src/main/java/com/oinzo/somoim/common/type/favorite.java
+++ b/src/main/java/com/oinzo/somoim/common/type/favorite.java
@@ -1,0 +1,7 @@
+package com.oinzo.somoim.common.type;
+
+public enum favorite {
+    SPORTS,
+    GAME,
+    TRIP
+}

--- a/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
@@ -19,28 +19,28 @@ public class ClubController {
 
     @ResponseBody
     @PostMapping()
-    public Object addClub(@RequestBody Club request){
+    public Club addClub(@RequestBody Club request){
         return clubService.addClub(request);
     }
 
     @GetMapping("/search")
-    public Object readClubByName(@RequestBody Club request) {
+    public List<Club> readClubByName(@RequestBody Club request) {
         return clubService.readClubByName(request);
     }
 
     @GetMapping("/favorite")
-    public Object readClubByFavorite(@RequestBody Club request){
+    public List<Club> readClubByFavorite(@RequestBody Club request){
         return clubService.readClubByFavorite(request);
     }
 
     @GetMapping("/{clubId}")
-    public Object readClubById(@PathVariable("clubId") Long clubId, HttpServletResponse response,
-                               @CookieValue(value="count", required=false) Cookie countCookie){
+    public Optional<Club> readClubById(@PathVariable("clubId") Long clubId, HttpServletResponse response,
+                                       @CookieValue(value="count", required=false) Cookie countCookie){
         return clubService.readClubById(clubId,response,countCookie);
     }
 
     @GetMapping("/random")
-    public Object readClubByArea(@RequestBody Club request){
+    public List<Club> readClubByArea(@RequestBody Club request){
         return clubService.readClubByArea(request);
     }
 

--- a/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
@@ -1,0 +1,32 @@
+package com.oinzo.somoim.domain.club;
+
+import com.oinzo.somoim.common.exception.ErrorResponse;
+import com.oinzo.somoim.domain.club.entity.Club;
+import com.oinzo.somoim.domain.club.service.ClubService;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import javax.servlet.http.Cookie;
+import java.util.List;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/club")
+public class ClubController {
+    private final ClubService clubService;
+
+    @ResponseBody
+    @PostMapping()
+    public Club addClub(@RequestBody Club request){
+        return clubService.addClub(request);
+    }
+
+    @GetMapping("/search")
+    public List<Club> readClubByName(@RequestBody String name) {
+        return clubService.readClubByName(name);
+    }
+
+    @GetMapping("/favorite")
+    public List<Club> readClubByFavorite(@RequestBody Club request){
+        return clubService.readClubByFavorite(request.getFavorite(),request.getArea());
+    }
+}

--- a/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
@@ -1,6 +1,7 @@
 package com.oinzo.somoim.domain.club;
 
 import com.oinzo.somoim.common.exception.ErrorCode;
+import com.oinzo.somoim.domain.club.dto.ClubRequestDto;
 import com.oinzo.somoim.domain.club.entity.Club;
 import com.oinzo.somoim.domain.club.service.ClubService;
 import lombok.AllArgsConstructor;
@@ -24,12 +25,12 @@ public class ClubController {
     }
 
     @GetMapping("/search")
-    public List<Club> readClubByName(@RequestBody Club request) {
+    public List<Club> readClubByName(@RequestBody ClubRequestDto request) {
         return clubService.readClubByName(request);
     }
 
     @GetMapping("/favorite")
-    public List<Club> readClubByFavorite(@RequestBody Club request){
+    public List<Club> readClubByFavorite(@RequestBody ClubRequestDto request){
         return clubService.readClubByFavorite(request);
     }
 
@@ -40,7 +41,7 @@ public class ClubController {
     }
 
     @GetMapping("/random")
-    public List<Club> readClubByArea(@RequestBody Club request){
+    public List<Club> readClubByArea(@RequestBody ClubRequestDto request){
         return clubService.readClubByArea(request);
     }
 

--- a/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
@@ -1,16 +1,18 @@
 package com.oinzo.somoim.domain.club;
 
-import com.oinzo.somoim.common.exception.ErrorResponse;
 import com.oinzo.somoim.domain.club.entity.Club;
 import com.oinzo.somoim.domain.club.service.ClubService;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @AllArgsConstructor
-@RequestMapping("/club")
+@RequestMapping("/clubs")
 public class ClubController {
     private final ClubService clubService;
 
@@ -28,5 +30,14 @@ public class ClubController {
     @GetMapping("/favorite")
     public List<Club> readClubByFavorite(@RequestBody Club request){
         return clubService.readClubByFavorite(request.getFavorite(),request.getArea());
+    }
+
+    @GetMapping("/{clubId}")
+    public Club readClubById(@PathVariable("clubId") Long clubId, HttpServletResponse response,
+                                        @CookieValue(value="count", required=false) Cookie countCookie){
+        Optional<Club> club = clubService.readClubById(clubId);
+        Integer newCnt = clubService.updateCookie(response,countCookie,clubId,club.get().getCnt());
+        clubService.updateCnt(clubId,newCnt);
+        return club.get();
     }
 }

--- a/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
@@ -30,7 +30,7 @@ public class ClubController {
 
     @GetMapping("/favorite")
     public Object readClubByFavorite(@RequestBody Club request){
-        return clubService.readClubByFavorite(request.getFavorite(),request.getArea());
+        return clubService.readClubByFavorite(request);
     }
 
     @GetMapping("/{clubId}")

--- a/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
@@ -1,5 +1,6 @@
 package com.oinzo.somoim.domain.club;
 
+import com.oinzo.somoim.common.exception.ErrorCode;
 import com.oinzo.somoim.domain.club.entity.Club;
 import com.oinzo.somoim.domain.club.service.ClubService;
 import lombok.AllArgsConstructor;
@@ -23,8 +24,10 @@ public class ClubController {
     }
 
     @GetMapping("/search")
-    public List<Club> readClubByName(@RequestBody String name) {
-        return clubService.readClubByName(name);
+    public Object readClubByName(@RequestBody String name) {
+        if(clubService.readClubByName(name).isEmpty())
+            return ErrorCode.NO_DATA_FOUND;
+        else {return clubService.readClubByName(name);}
     }
 
     @GetMapping("/favorite")
@@ -33,11 +36,25 @@ public class ClubController {
     }
 
     @GetMapping("/{clubId}")
-    public Club readClubById(@PathVariable("clubId") Long clubId, HttpServletResponse response,
-                                        @CookieValue(value="count", required=false) Cookie countCookie){
+    public Object readClubById(@PathVariable("clubId") Long clubId, HttpServletResponse response,
+                               @CookieValue(value="count", required=false) Cookie countCookie){
         Optional<Club> club = clubService.readClubById(clubId);
-        Integer newCnt = clubService.updateCookie(response,countCookie,clubId,club.get().getCnt());
-        clubService.updateCnt(clubId,newCnt);
-        return club.get();
+        if(club.isPresent())
+        {
+            Integer newCnt = clubService.updateCookie(response,countCookie,clubId,club.get().getCnt());
+            clubService.updateCnt(clubId,newCnt);
+            return club.get();
+        }
+        else return ErrorCode.WRONG_CLUB;
     }
+
+    @GetMapping("/random")
+    public Object readClubByArea(@RequestBody Club request){
+        List<Club> result = clubService.readClubByArea(request.getArea());
+        if(result.isEmpty())
+            return ErrorCode.NO_DATA_FOUND;
+        else return clubService.readClubByArea(request.getArea());
+    }
+
+
 }

--- a/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
@@ -19,41 +19,29 @@ public class ClubController {
 
     @ResponseBody
     @PostMapping()
-    public Club addClub(@RequestBody Club request){
+    public Object addClub(@RequestBody Club request){
         return clubService.addClub(request);
     }
 
     @GetMapping("/search")
-    public Object readClubByName(@RequestBody String name) {
-        if(clubService.readClubByName(name).isEmpty())
-            return ErrorCode.NO_DATA_FOUND;
-        else {return clubService.readClubByName(name);}
+    public Object readClubByName(@RequestBody Club request) {
+        return clubService.readClubByName(request);
     }
 
     @GetMapping("/favorite")
-    public List<Club> readClubByFavorite(@RequestBody Club request){
+    public Object readClubByFavorite(@RequestBody Club request){
         return clubService.readClubByFavorite(request.getFavorite(),request.getArea());
     }
 
     @GetMapping("/{clubId}")
     public Object readClubById(@PathVariable("clubId") Long clubId, HttpServletResponse response,
                                @CookieValue(value="count", required=false) Cookie countCookie){
-        Optional<Club> club = clubService.readClubById(clubId);
-        if(club.isPresent())
-        {
-            Integer newCnt = clubService.updateCookie(response,countCookie,clubId,club.get().getCnt());
-            clubService.updateCnt(clubId,newCnt);
-            return club.get();
-        }
-        else return ErrorCode.WRONG_CLUB;
+        return clubService.readClubById(clubId,response,countCookie);
     }
 
     @GetMapping("/random")
     public Object readClubByArea(@RequestBody Club request){
-        List<Club> result = clubService.readClubByArea(request.getArea());
-        if(result.isEmpty())
-            return ErrorCode.NO_DATA_FOUND;
-        else return clubService.readClubByArea(request.getArea());
+        return clubService.readClubByArea(request);
     }
 
 

--- a/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
@@ -1,6 +1,7 @@
 package com.oinzo.somoim.domain.club;
 
 import com.oinzo.somoim.common.exception.ErrorCode;
+import com.oinzo.somoim.domain.club.dto.ClubCreateDto;
 import com.oinzo.somoim.domain.club.dto.ClubRequestDto;
 import com.oinzo.somoim.domain.club.entity.Club;
 import com.oinzo.somoim.domain.club.service.ClubService;
@@ -20,7 +21,7 @@ public class ClubController {
 
     @ResponseBody
     @PostMapping()
-    public Club addClub(@RequestBody Club request){
+    public Club addClub(@RequestBody ClubCreateDto request){
         return clubService.addClub(request);
     }
 

--- a/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/ClubController.java
@@ -19,30 +19,29 @@ import java.util.Optional;
 public class ClubController {
     private final ClubService clubService;
 
-    @ResponseBody
     @PostMapping()
     public Club addClub(@RequestBody ClubCreateDto request){
         return clubService.addClub(request);
     }
 
     @GetMapping("/search")
-    public List<Club> readClubByName(@RequestBody ClubRequestDto request) {
-        return clubService.readClubByName(request);
+    public List<Club> readClubListByName(@RequestBody ClubRequestDto request) {
+        return clubService.readClubListByName(request);
     }
 
     @GetMapping("/favorite")
-    public List<Club> readClubByFavorite(@RequestBody ClubRequestDto request){
-        return clubService.readClubByFavorite(request);
+    public List<Club> readClubByListFavorite(@RequestBody ClubRequestDto request){
+        return clubService.readClubListByFavorite(request);
     }
 
     @GetMapping("/{clubId}")
-    public Optional<Club> readClubById(@PathVariable("clubId") Long clubId, HttpServletResponse response,
+    public Club readClubById(@PathVariable("clubId") Long clubId, HttpServletResponse response,
                                        @CookieValue(value="count", required=false) Cookie countCookie){
         return clubService.readClubById(clubId,response,countCookie);
     }
 
     @GetMapping("/random")
-    public List<Club> readClubByArea(@RequestBody ClubRequestDto request){
+    public List<Club> readClubListByArea(@RequestBody ClubRequestDto request){
         return clubService.readClubByArea(request);
     }
 

--- a/src/main/java/com/oinzo/somoim/domain/club/dto/ClubCreateDto.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/dto/ClubCreateDto.java
@@ -11,7 +11,6 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ClubCreateDto {
 
-    private Long id;
     private String name;
     private String description;
     private String imageUrl;

--- a/src/main/java/com/oinzo/somoim/domain/club/dto/ClubCreateDto.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/dto/ClubCreateDto.java
@@ -1,0 +1,23 @@
+package com.oinzo.somoim.domain.club.dto;
+
+import com.sun.istack.NotNull;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ClubCreateDto {
+
+    private Long id;
+    private String name;
+    private String description;
+    private String imageUrl;
+    private String area;
+    private int memberLimit;
+    private int memberCnt;
+    private String favorite;
+
+}

--- a/src/main/java/com/oinzo/somoim/domain/club/dto/ClubRequestDto.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/dto/ClubRequestDto.java
@@ -30,7 +30,7 @@ public class ClubRequestDto {
     private int memberLimit;
     private int memberCnt;
     private String favorite;
-    private int cnt;
+    private int viewCnt;
 
 
 }

--- a/src/main/java/com/oinzo/somoim/domain/club/dto/ClubRequestDto.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/dto/ClubRequestDto.java
@@ -1,0 +1,36 @@
+package com.oinzo.somoim.domain.club.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+public class ClubRequestDto {
+    private String name;
+
+    public ClubRequestDto setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public ClubRequestDto setArea(String area) {
+        this.area = area;
+        return this;
+    }
+
+    public ClubRequestDto setFavorite(String favorite) {
+        this.favorite = favorite;
+        return this;
+    }
+
+    private String description;
+    private String imageUrl;
+    private String area;
+    private int memberLimit;
+    private int memberCnt;
+    private String favorite;
+    private int cnt;
+
+
+}

--- a/src/main/java/com/oinzo/somoim/domain/club/entity/Club.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/entity/Club.java
@@ -1,0 +1,37 @@
+package com.oinzo.somoim.domain.club.entity;
+
+import com.oinzo.somoim.common.entity.BaseEntity;
+import com.sun.istack.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Builder
+public class Club extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @NotNull
+    private String name;
+    private String description;
+    private String imageUrl;
+    @NotNull
+    private String area;
+    @NotNull
+    private int memberLimit;
+    @NotNull
+    private int memberCnt;
+    @NotNull
+    private String favorite;
+    private int cnt;
+}

--- a/src/main/java/com/oinzo/somoim/domain/club/entity/Club.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/entity/Club.java
@@ -32,6 +32,12 @@ public class Club extends BaseEntity {
     private int memberCnt;
     @NotNull
     private String favorite;
+
+    public Club setCnt(int cnt) {
+        this.cnt = cnt;
+        return this;
+    }
+
     private int cnt;
 
     public static Club from(Club club){
@@ -41,7 +47,10 @@ public class Club extends BaseEntity {
                 .imageUrl(club.getImageUrl())
                 .area(club.getArea())
                 .memberLimit(club.getMemberLimit())
+                .memberCnt(0)
                 .favorite(club.getFavorite())
+                .cnt(0)
                 .build();
     }
+
 }

--- a/src/main/java/com/oinzo/somoim/domain/club/entity/Club.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/entity/Club.java
@@ -1,16 +1,14 @@
 package com.oinzo.somoim.domain.club.entity;
 
 import com.oinzo.somoim.common.entity.BaseEntity;
+import com.oinzo.somoim.domain.club.dto.ClubCreateDto;
 import com.sun.istack.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Getter
 @NoArgsConstructor
@@ -23,15 +21,27 @@ public class Club extends BaseEntity {
     private Long id;
     @NotNull
     private String name;
+    @NotNull
     private String description;
+    @NotNull
     private String imageUrl;
     @NotNull
     private String area;
     @NotNull
     private int memberLimit;
-    @NotNull
     private int memberCnt;
     @NotNull
     private String favorite;
     private int cnt;
+
+    public static Club from(Club club){
+        return Club.builder()
+                .name(club.getName())
+                .description(club.getDescription())
+                .imageUrl(club.getImageUrl())
+                .area(club.getArea())
+                .memberLimit(club.getMemberLimit())
+                .favorite(club.getFavorite())
+                .build();
+    }
 }

--- a/src/main/java/com/oinzo/somoim/domain/club/entity/Club.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/entity/Club.java
@@ -34,11 +34,11 @@ public class Club extends BaseEntity {
     private String favorite;
 
     public Club setCnt(int cnt) {
-        this.cnt = cnt;
+        this.viewCnt = cnt;
         return this;
     }
 
-    private int cnt;
+    private int viewCnt;
 
     public static Club from(ClubCreateDto clubCreateDto){
         return Club.builder()
@@ -49,7 +49,7 @@ public class Club extends BaseEntity {
                 .memberLimit(clubCreateDto.getMemberLimit())
                 .memberCnt(0)
                 .favorite(clubCreateDto.getFavorite())
-                .cnt(0)
+                .viewCnt(0)
                 .build();
     }
 

--- a/src/main/java/com/oinzo/somoim/domain/club/entity/Club.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/entity/Club.java
@@ -40,15 +40,15 @@ public class Club extends BaseEntity {
 
     private int cnt;
 
-    public static Club from(Club club){
+    public static Club from(ClubCreateDto clubCreateDto){
         return Club.builder()
-                .name(club.getName())
-                .description(club.getDescription())
-                .imageUrl(club.getImageUrl())
-                .area(club.getArea())
-                .memberLimit(club.getMemberLimit())
+                .name(clubCreateDto.getName())
+                .description(clubCreateDto.getDescription())
+                .imageUrl(clubCreateDto.getImageUrl())
+                .area(clubCreateDto.getArea())
+                .memberLimit(clubCreateDto.getMemberLimit())
                 .memberCnt(0)
-                .favorite(club.getFavorite())
+                .favorite(clubCreateDto.getFavorite())
                 .cnt(0)
                 .build();
     }

--- a/src/main/java/com/oinzo/somoim/domain/club/repository/ClubRepository.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/repository/ClubRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ClubRepository extends JpaRepository<Club, Long> {
@@ -14,5 +15,7 @@ public interface ClubRepository extends JpaRepository<Club, Long> {
     List<Club> findAllByFavoriteContainingAndAreaContaining(String favorite,String area);
 
     List<Club> findAllByAreaLikeOrderByCntDesc(String area);
+
+    Optional<Club> findByName(String name);
 
 }

--- a/src/main/java/com/oinzo/somoim/domain/club/repository/ClubRepository.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/repository/ClubRepository.java
@@ -1,0 +1,18 @@
+package com.oinzo.somoim.domain.club.repository;
+
+import com.oinzo.somoim.domain.club.entity.Club;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ClubRepository extends JpaRepository<Club, Long> {
+
+    List<Club> findAllByNameContaining(String name);
+
+    List<Club> findAllByFavoriteContainingAndAreaContaining(String favorite,String area);
+
+    List<Club> findAllByAreaLikeOrderByCntDesc(String area);
+
+}

--- a/src/main/java/com/oinzo/somoim/domain/club/repository/ClubRepository.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/repository/ClubRepository.java
@@ -16,6 +16,5 @@ public interface ClubRepository extends JpaRepository<Club, Long> {
 
     List<Club> findAllByAreaLikeOrderByCntDesc(String area);
 
-    Optional<Club> findByName(String name);
 
 }

--- a/src/main/java/com/oinzo/somoim/domain/club/repository/ClubRepository.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/repository/ClubRepository.java
@@ -14,7 +14,7 @@ public interface ClubRepository extends JpaRepository<Club, Long> {
 
     List<Club> findAllByFavoriteContainingAndAreaContaining(String favorite,String area);
 
-    List<Club> findAllByAreaLikeOrderByCntDesc(String area);
+    List<Club> findAllByAreaLikeOrderByViewCntDesc(String area);
 
 
 }

--- a/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
@@ -101,7 +101,7 @@ public class ClubService {
                 }
             }
             countCookie.setValue(newValue);
-            countCookie.setMaxAge(60*60*24);
+            countCookie.setMaxAge(countCookie.getMaxAge());
             countCookie.setPath("/");
             response.addCookie(countCookie);
             return clubCnt;

--- a/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
@@ -32,7 +32,7 @@ public class ClubService {
         }
     }
 
-    public List<Club> readClubByName(ClubRequestDto request){
+    public List<Club> readClubListByName(ClubRequestDto request){
         try{
             String name = request.getName();
             List<Club> result = clubRepository.findAllByNameContaining(name);
@@ -44,7 +44,7 @@ public class ClubService {
         }
     }
 
-    public List<Club> readClubByFavorite(ClubRequestDto request){
+    public List<Club> readClubListByFavorite(ClubRequestDto request){
         String favorite = request.getFavorite();
         String area = request.getArea();
         List<Club> result = clubRepository.findAllByFavoriteContainingAndAreaContaining(favorite,area);
@@ -62,20 +62,20 @@ public class ClubService {
         }
     }
 
-    public Optional<Club> readClubById(Long clubId,HttpServletResponse response, Cookie countCookie ){
+    public Club readClubById(Long clubId,HttpServletResponse response, Cookie countCookie ){
         Optional<Club> club = clubRepository.findById(clubId);
         if(club.isPresent())
         {
-            Integer newCnt = updateCookie(response,countCookie,clubId,club.get().getCnt());
+            Integer newCnt = updateCookie(response,countCookie,clubId,club.get().getViewCnt());
             updateCnt(club.get(),newCnt);
-            return club;
+            return club.get();
         } else throw new BaseException(ErrorCode.WRONG_CLUB,ErrorCode.WRONG_CLUB.getMessage());
     }
 
     public List<Club> readClubByArea(ClubRequestDto request){
         if(request.getArea().isEmpty())
             throw  new BaseException(ErrorCode.NO_DATA_FOUND,ErrorCode.NO_DATA_FOUND.getMessage());
-        return clubRepository.findAllByAreaLikeOrderByCntDesc(request.getArea());
+        return clubRepository.findAllByAreaLikeOrderByViewCntDesc(request.getArea());
     }
 
     public Integer updateCookie(HttpServletResponse response, Cookie countCookie, Long clubId, Integer clubCnt){

--- a/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
@@ -22,7 +22,7 @@ public class ClubService {
 
     private final ClubRepository clubRepository;
 
-    public Club addClub(Club club){
+    public Club addClub(ClubCreateDto club){
         String favorite = club.getFavorite();
         try{
             Favorite.valueOf(favorite);

--- a/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
@@ -1,0 +1,30 @@
+package com.oinzo.somoim.domain.club.service;
+
+import com.oinzo.somoim.domain.club.dto.ClubCreateDto;
+import com.oinzo.somoim.domain.club.entity.Club;
+import com.oinzo.somoim.domain.club.repository.ClubRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+public class ClubService {
+
+    private final ClubRepository clubRepository;
+
+    public Club addClub(Club club){
+        return clubRepository.save(Club.from(club));
+    }
+
+    public List<Club> readClubByName(String name){
+        return clubRepository.findAllByNameContaining(name);
+    }
+
+    public List<Club> readClubByFavorite(String favorite, String area){
+        return clubRepository.findAllByFavoriteContainingAndAreaContaining(favorite,area);
+    }
+
+}

--- a/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
@@ -4,6 +4,7 @@ import com.oinzo.somoim.common.exception.BaseException;
 import com.oinzo.somoim.common.exception.ErrorCode;
 import com.oinzo.somoim.common.type.Favorite;
 import com.oinzo.somoim.domain.club.dto.ClubCreateDto;
+import com.oinzo.somoim.domain.club.dto.ClubRequestDto;
 import com.oinzo.somoim.domain.club.entity.Club;
 import com.oinzo.somoim.domain.club.repository.ClubRepository;
 import lombok.AllArgsConstructor;
@@ -31,7 +32,7 @@ public class ClubService {
         }
     }
 
-    public List<Club> readClubByName(Club request){
+    public List<Club> readClubByName(ClubRequestDto request){
         try{
             String name = request.getName();
             List<Club> result = clubRepository.findAllByNameContaining(name);
@@ -43,7 +44,7 @@ public class ClubService {
         }
     }
 
-    public List<Club> readClubByFavorite(Club request){
+    public List<Club> readClubByFavorite(ClubRequestDto request){
         String favorite = request.getFavorite();
         String area = request.getArea();
         List<Club> result = clubRepository.findAllByFavoriteContainingAndAreaContaining(favorite,area);
@@ -71,7 +72,7 @@ public class ClubService {
         } else throw new BaseException(ErrorCode.WRONG_CLUB,ErrorCode.WRONG_CLUB.getMessage());
     }
 
-    public List<Club> readClubByArea(Club request){
+    public List<Club> readClubByArea(ClubRequestDto request){
         if(request.getArea().isEmpty())
             throw  new BaseException(ErrorCode.NO_DATA_FOUND,ErrorCode.NO_DATA_FOUND.getMessage());
         return clubRepository.findAllByAreaLikeOrderByCntDesc(request.getArea());

--- a/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
@@ -1,5 +1,6 @@
 package com.oinzo.somoim.domain.club.service;
 
+import com.oinzo.somoim.common.exception.BaseException;
 import com.oinzo.somoim.common.exception.ErrorCode;
 import com.oinzo.somoim.common.type.Favorite;
 import com.oinzo.somoim.domain.club.dto.ClubCreateDto;
@@ -20,56 +21,56 @@ public class ClubService {
 
     private final ClubRepository clubRepository;
 
-    public Object addClub(Club club){
+    public Club addClub(Club club){
         String favorite = club.getFavorite();
         try{
             Favorite.valueOf(favorite);
             return clubRepository.save(Club.from(club));
         } catch (IllegalArgumentException e)  {
-            return ErrorCode.WRONG_FAVORITE;
+            throw new BaseException(ErrorCode.WRONG_FAVORITE,ErrorCode.WRONG_FAVORITE.getMessage());
         }
     }
 
-    public Object readClubByName(Club request){
+    public List<Club> readClubByName(Club request){
         try{
             String name = request.getName();
             List<Club> result = clubRepository.findAllByNameContaining(name);
-            if(name.length()<1) { return ErrorCode.NO_SEARCH_NAME; }
-            else if (result.isEmpty()) { return ErrorCode.NO_DATA_FOUND; }
+            if(name.length()<1) throw new BaseException(ErrorCode.NO_SEARCH_NAME,ErrorCode.NO_SEARCH_NAME.getMessage());
+            else if (result.isEmpty()) { throw new BaseException(ErrorCode.NO_DATA_FOUND,ErrorCode.NO_DATA_FOUND.getMessage()); }
             else{ return clubRepository.findAllByNameContaining(name); }
         }catch (IllegalArgumentException e) {
-            return ErrorCode.NO_SEARCH_NAME;
+            throw new BaseException(ErrorCode.NO_SEARCH_NAME,ErrorCode.NO_SEARCH_NAME.getMessage());
         }
     }
 
-    public Object readClubByFavorite(Club request){
+    public List<Club> readClubByFavorite(Club request){
         String favorite = request.getFavorite();
         String area = request.getArea();
         List<Club> result = clubRepository.findAllByFavoriteContainingAndAreaContaining(favorite,area);
-        if(favorite.length()<1) { return ErrorCode.NO_SEARCH_NAME; }
+        if(favorite.length()<1) { throw new BaseException(ErrorCode.NO_SEARCH_NAME,ErrorCode.NO_SEARCH_NAME.getMessage()); }
         try{
             Favorite.valueOf(favorite);
-            if (result.isEmpty()) { return ErrorCode.NO_DATA_FOUND; }
+            if (result.isEmpty()) { throw new BaseException(ErrorCode.NO_DATA_FOUND,ErrorCode.NO_DATA_FOUND.getMessage()); }
             else { return result; }
-        } catch (IllegalArgumentException e)  {
-            return ErrorCode.WRONG_FAVORITE;
+        } catch (RuntimeException e)  {
+            throw new BaseException(ErrorCode.WRONG_FAVORITE,ErrorCode.WRONG_FAVORITE.getMessage());
         }
     }
 
-    public Object readClubById(Long clubId,HttpServletResponse response, Cookie countCookie ){
+    public Optional<Club> readClubById(Long clubId,HttpServletResponse response, Cookie countCookie ){
         Optional<Club> club = clubRepository.findById(clubId);
         if(club.isPresent())
         {
             Integer newCnt = updateCookie(response,countCookie,clubId,club.get().getCnt());
             updateCnt(club.get(),newCnt);
-            return club.get();
+            return club;
         }
-        else return ErrorCode.WRONG_CLUB;
+        else throw new BaseException(ErrorCode.WRONG_CLUB,ErrorCode.WRONG_CLUB.getMessage());
     }
 
-    public Object readClubByArea(Club request){
+    public List<Club> readClubByArea(Club request){
         if(request.getArea().isEmpty())
-            return ErrorCode.NO_DATA_FOUND;
+            throw  new BaseException(ErrorCode.NO_DATA_FOUND,ErrorCode.NO_DATA_FOUND.getMessage());
         return clubRepository.findAllByAreaLikeOrderByCntDesc(request.getArea());
     }
 

--- a/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
@@ -42,7 +42,9 @@ public class ClubService {
         }
     }
 
-    public Object readClubByFavorite(String favorite, String area){
+    public Object readClubByFavorite(Club request){
+        String favorite = request.getFavorite();
+        String area = request.getArea();
         List<Club> result = clubRepository.findAllByFavoriteContainingAndAreaContaining(favorite,area);
         if(favorite.length()<1) { return ErrorCode.NO_SEARCH_NAME; }
         try{

--- a/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
@@ -36,8 +36,8 @@ public class ClubService {
             String name = request.getName();
             List<Club> result = clubRepository.findAllByNameContaining(name);
             if(name.length()<1) throw new BaseException(ErrorCode.NO_SEARCH_NAME,ErrorCode.NO_SEARCH_NAME.getMessage());
-            else if (result.isEmpty()) { throw new BaseException(ErrorCode.NO_DATA_FOUND,ErrorCode.NO_DATA_FOUND.getMessage()); }
-            else{ return clubRepository.findAllByNameContaining(name); }
+            else if (result.isEmpty()) throw new BaseException(ErrorCode.NO_DATA_FOUND,ErrorCode.NO_DATA_FOUND.getMessage());
+            else return clubRepository.findAllByNameContaining(name);
         }catch (IllegalArgumentException e) {
             throw new BaseException(ErrorCode.NO_SEARCH_NAME,ErrorCode.NO_SEARCH_NAME.getMessage());
         }
@@ -47,11 +47,15 @@ public class ClubService {
         String favorite = request.getFavorite();
         String area = request.getArea();
         List<Club> result = clubRepository.findAllByFavoriteContainingAndAreaContaining(favorite,area);
-        if(favorite.length()<1) { throw new BaseException(ErrorCode.NO_SEARCH_NAME,ErrorCode.NO_SEARCH_NAME.getMessage()); }
+        if (favorite.length()<1)
+            throw new BaseException(ErrorCode.NO_SEARCH_NAME,ErrorCode.NO_SEARCH_NAME.getMessage());
         try{
             Favorite.valueOf(favorite);
-            if (result.isEmpty()) { throw new BaseException(ErrorCode.NO_DATA_FOUND,ErrorCode.NO_DATA_FOUND.getMessage()); }
-            else { return result; }
+            if (result.isEmpty()) {
+                throw new BaseException(ErrorCode.NO_DATA_FOUND,ErrorCode.NO_DATA_FOUND.getMessage());
+            } else {
+                return result;
+            }
         } catch (RuntimeException e)  {
             throw new BaseException(ErrorCode.WRONG_FAVORITE,ErrorCode.WRONG_FAVORITE.getMessage());
         }
@@ -64,8 +68,7 @@ public class ClubService {
             Integer newCnt = updateCookie(response,countCookie,clubId,club.get().getCnt());
             updateCnt(club.get(),newCnt);
             return club;
-        }
-        else throw new BaseException(ErrorCode.WRONG_CLUB,ErrorCode.WRONG_CLUB.getMessage());
+        } else throw new BaseException(ErrorCode.WRONG_CLUB,ErrorCode.WRONG_CLUB.getMessage());
     }
 
     public List<Club> readClubByArea(Club request){
@@ -89,7 +92,7 @@ public class ClubService {
                         clubCnt -= 1;
                     }
                 }
-            }else {
+            } else {
                 if(Objects.equals(counts[0], clubId.toString()))
                 {
                     newValue = cookieCount;
@@ -101,8 +104,7 @@ public class ClubService {
             countCookie.setPath("/");
             response.addCookie(countCookie);
             return clubCnt;
-        }
-        else {
+        } else {
             Cookie newCookie = new Cookie("count",clubId.toString());
             newCookie.setMaxAge(60*60*24);
             newCookie.setPath("/");

--- a/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
@@ -6,8 +6,11 @@ import com.oinzo.somoim.domain.club.repository.ClubRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Optional;
+import java.util.Objects;
 
 @Service
 @AllArgsConstructor
@@ -25,6 +28,56 @@ public class ClubService {
 
     public List<Club> readClubByFavorite(String favorite, String area){
         return clubRepository.findAllByFavoriteContainingAndAreaContaining(favorite,area);
+    }
+
+    public Optional<Club> readClubById(Long clubId){
+        return clubRepository.findById(clubId);
+    }
+
+    public List<Club> readClubByArea(String area){
+        return clubRepository.findAllByAreaLikeOrderByCntDesc(area);
+    }
+
+    public Integer updateCookie(HttpServletResponse response, Cookie countCookie, Long clubId, Integer clubCnt){
+        clubCnt += 1;
+        if(countCookie!=null){
+            String cookieCount = countCookie.getValue();
+            String newValue = cookieCount+"_"+clubId.toString();
+            String[] counts = cookieCount.split("_");
+
+            if(counts.length!=1)
+            {
+                for (String count : counts) {
+                    if (Objects.equals(count, clubId.toString())) {
+                        newValue = cookieCount;
+                        clubCnt -= 1;
+                    }
+                }
+            }else {
+                if(Objects.equals(counts[0], clubId.toString()))
+                {
+                    newValue = cookieCount;
+                    clubCnt -=1;
+                }
+            }
+            countCookie.setValue(newValue);
+            countCookie.setMaxAge(60*60*24);
+            countCookie.setPath("/");
+            response.addCookie(countCookie);
+            return clubCnt;
+        }
+        else {
+            Cookie newCookie = new Cookie("count",clubId.toString());
+            newCookie.setMaxAge(60*60*24);
+            newCookie.setPath("/");
+            response.addCookie(newCookie);
+            return clubCnt;
+        }
+    }
+
+    public void updateCnt(Long clubId, Integer cnt){
+        Optional<Club> club2 = clubRepository.findById(clubId);
+        club2.ifPresent(clubRepository::save);
     }
 
 }

--- a/src/test/java/com/oinzo/somoim/ClubControllerTest.java
+++ b/src/test/java/com/oinzo/somoim/ClubControllerTest.java
@@ -49,7 +49,7 @@ class ClubControllerTest {
         /* given */
         ClubRequestDto newClub = new ClubRequestDto().setName("1");
         /* when */
-        List<Club> result = clubService.readClubByName(newClub);
+        List<Club> result = clubService.readClubListByName(newClub);
         /* then */
         assertTrue(result.size()>1);
     }
@@ -60,7 +60,7 @@ class ClubControllerTest {
         /* given */
         ClubRequestDto newClub = new ClubRequestDto().setFavorite("SPORTS").setArea("서울");
         /* when */;
-        List<Club> result = clubService.readClubByFavorite(newClub);
+        List<Club> result = clubService.readClubListByFavorite(newClub);
         System.out.println(result.size());
         /* then */
         assertTrue(1 < result.size());

--- a/src/test/java/com/oinzo/somoim/ClubControllerTest.java
+++ b/src/test/java/com/oinzo/somoim/ClubControllerTest.java
@@ -1,6 +1,7 @@
 package com.oinzo.somoim;
 
 import com.oinzo.somoim.common.exception.ErrorCode;
+import com.oinzo.somoim.domain.club.dto.ClubRequestDto;
 import com.oinzo.somoim.domain.club.entity.Club;
 import com.oinzo.somoim.domain.club.repository.ClubRepository;
 import com.oinzo.somoim.domain.club.service.ClubService;
@@ -45,40 +46,30 @@ class ClubControllerTest {
     @DisplayName("클럽 이름으로 조회 테스트")
     void readClubByName() {
         /* given */
-        Club newClub = new Club(0L,"!?","테스트용 클럽","클럽대표사진1","서울",3,0,"SPORTS",0);
+        ClubRequestDto newClub = new ClubRequestDto().setName("1");
         /* when */
-        Object result = clubService.readClubByName(newClub);
+        List<Club> result = clubService.readClubByName(newClub);
         /* then */
-        Assertions.assertEquals(ErrorCode.NO_DATA_FOUND,result);
+        assertTrue(result.size()>1);
     }
 
     @Test
     @DisplayName("클럽 관심사로 조회 테스트")
     void readClubByFavorite() {
         /* given */
-        Club newClub = new Club(0L,"!?","테스트용 클럽","클럽대표사진1","서울",3,0,"SPORTS",0);
+        ClubRequestDto newClub = new ClubRequestDto().setFavorite("SPORTS").setArea("서울");
         /* when */;
-        Object result = clubService.readClubByFavorite(newClub);
+        List<Club> result = clubService.readClubByFavorite(newClub);
+        System.out.println(result.size());
         /* then */
-        assertTrue(1 < ((List<Club>) result).size());
-    }
-
-    @Test
-    @DisplayName("클럽 관심사로 조회 실패 테스트")
-    void readClubByFavoriteFaile() {
-        /* given */
-        Club newClub = new Club(0L,"!?","테스트용 클럽","클럽대표사진1","서울",3,0,"SPORT",0);
-        /* when */;
-        Object result = clubService.readClubByFavorite(newClub);
-        /* then */
-        Assertions.assertEquals(result,ErrorCode.WRONG_FAVORITE);
+        assertTrue(1 < result.size());
     }
 
     @Test
     @DisplayName("클럽 랜덤 검색 테스트")
     void readClubByArea() {
         /* given */
-        Club newClub = new Club(0L,"!?","테스트용 클럽","클럽대표사진1","서울",3,0,"SPORT",0);
+        ClubRequestDto newClub = new ClubRequestDto().setArea("서울").setFavorite("SPORTS");
         /* when */;
         Object result = clubService.readClubByArea(newClub);
         /* then */

--- a/src/test/java/com/oinzo/somoim/ClubControllerTest.java
+++ b/src/test/java/com/oinzo/somoim/ClubControllerTest.java
@@ -1,0 +1,87 @@
+package com.oinzo.somoim;
+
+import com.oinzo.somoim.common.exception.ErrorCode;
+import com.oinzo.somoim.domain.club.entity.Club;
+import com.oinzo.somoim.domain.club.repository.ClubRepository;
+import com.oinzo.somoim.domain.club.service.ClubService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.util.Assert;
+import org.springframework.web.bind.annotation.CookieValue;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.description;
+
+@SpringBootTest
+class ClubControllerTest {
+
+    @Autowired
+    ClubRepository clubRepository;
+
+    @Autowired
+    ClubService clubService;
+
+    @Test
+    @DisplayName("클럽 생성 테스트")
+    void addClub() {
+        /* given */
+        Club newClub = new Club(0L,"새로운 클럽","테스트용 클럽","클럽대표사진1","서울",3,0,"SPORTS",0);
+        /* when */
+        Club club = clubRepository.save(Club.from(newClub));
+        /* then */
+        Assertions.assertEquals(club.getName(),"새로운 클럽");
+        Assertions.assertEquals(club.getMemberCnt(),0);
+    }
+
+    @Test
+    @DisplayName("클럽 이름으로 조회 테스트")
+    void readClubByName() {
+        /* given */
+        Club newClub = new Club(0L,"!?","테스트용 클럽","클럽대표사진1","서울",3,0,"SPORTS",0);
+        /* when */
+        Object result = clubService.readClubByName(newClub);
+        /* then */
+        Assertions.assertEquals(ErrorCode.NO_DATA_FOUND,result);
+    }
+
+    @Test
+    @DisplayName("클럽 관심사로 조회 테스트")
+    void readClubByFavorite() {
+        /* given */
+        Club newClub = new Club(0L,"!?","테스트용 클럽","클럽대표사진1","서울",3,0,"SPORTS",0);
+        /* when */;
+        Object result = clubService.readClubByFavorite(newClub);
+        /* then */
+        assertTrue(1 < ((List<Club>) result).size());
+    }
+
+    @Test
+    @DisplayName("클럽 관심사로 조회 실패 테스트")
+    void readClubByFavoriteFaile() {
+        /* given */
+        Club newClub = new Club(0L,"!?","테스트용 클럽","클럽대표사진1","서울",3,0,"SPORT",0);
+        /* when */;
+        Object result = clubService.readClubByFavorite(newClub);
+        /* then */
+        Assertions.assertEquals(result,ErrorCode.WRONG_FAVORITE);
+    }
+
+    @Test
+    @DisplayName("클럽 랜덤 검색 테스트")
+    void readClubByArea() {
+        /* given */
+        Club newClub = new Club(0L,"!?","테스트용 클럽","클럽대표사진1","서울",3,0,"SPORT",0);
+        /* when */;
+        Object result = clubService.readClubByArea(newClub);
+        /* then */
+        assertTrue(1 < ((List<Club>) result).size());
+    }
+}

--- a/src/test/java/com/oinzo/somoim/ClubControllerTest.java
+++ b/src/test/java/com/oinzo/somoim/ClubControllerTest.java
@@ -1,6 +1,7 @@
 package com.oinzo.somoim;
 
 import com.oinzo.somoim.common.exception.ErrorCode;
+import com.oinzo.somoim.domain.club.dto.ClubCreateDto;
 import com.oinzo.somoim.domain.club.dto.ClubRequestDto;
 import com.oinzo.somoim.domain.club.entity.Club;
 import com.oinzo.somoim.domain.club.repository.ClubRepository;
@@ -34,7 +35,7 @@ class ClubControllerTest {
     @DisplayName("클럽 생성 테스트")
     void addClub() {
         /* given */
-        Club newClub = new Club(0L,"새로운 클럽","테스트용 클럽","클럽대표사진1","서울",3,0,"SPORTS",0);
+        ClubCreateDto newClub = new ClubCreateDto("새로운 클럽","테스트용 클럽","클럽대표사진1","서울",3,0,"SPORTS");
         /* when */
         Club club = clubRepository.save(Club.from(newClub));
         /* then */


### PR DESCRIPTION
## 구현 내용
클럽 생성 및 조회 기능 구현입니다.
클럽 이름,설명,사진,멤버 정원,관심사,지역 등을 필수로 입력 받아 클럽을 생성합니다.
클럽 관심사의 경우 지정된 키워드가 아닐 시 에러를 반환합니다.
클럽 이름으로 해당 키워드를 포함한 모든 클럽 리스트를 조회합니다.
클럽 관심사로 해당 관심사를 가진 모든 클럽 리스트를 조회합니다.
클럽 아이디 검색을 사용하여 클럽 상세 정보 조회가 가능합니다.
상세 정보 조회 시 조회수 카운트가 1씩 증가합니다.
클럽 랜덤 검색은 지정한 지역내 조회수가 가장 높은 순으로 클럽 리스트를 반환합니다.

후에 멤버 정보와 관련된 부분을 연결할 예정입니다. 

<br>

## 관련 이슈
- https://github.com/SomoimProj/backend/issues/2 

