### PR TITLE
chore: CI 설정

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -1,0 +1,38 @@
+name: Spring Boot & Gradle CI
+
+on:
+  push:
+    branches: [ 'main', 'develop' ]
+    pull_request: [ 'main', 'develop' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      # Git Secret을 이용한 application-xxx.yml 생성
+      - name: Set Secret yml
+        run:
+          echo $SECRET_YML | base64 --decode > src/main/resources/application-secret.yml &&
+          echo $PROD_YML | base64 --decode > src/main/resources/application-prod.yml
+        env:
+          SECRET_YML: ${{ secrets.SECRET_YML }}
+          PROD_YML: ${{ secrets.PROD_YML }}
+
+      # gradlew에 대한 권한 부여
+      - name: Run chmod to make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: build
+


### PR DESCRIPTION
## 구현 내용
main, develop 브랜치에 푸쉬하거나 머지할 때 Github Action으로 build를 시도해봄으로써 실행 가능한 코드인지 확인하는 스크립트를 작성하였습니다.
배포 환경과 동일한 환경으로 설정하기 때문에 추후 배포 자동화할 때 jar 파일을 활용할 수 있을 것으로 예상됩니다.

<br>

## 관련 이슈
- #7

