### PR TITLE
Feat/16 user info

### DIFF
--- a/src/main/java/com/oinzo/somoim/common/annotation/Birth.java
+++ b/src/main/java/com/oinzo/somoim/common/annotation/Birth.java
@@ -1,0 +1,17 @@
+package com.oinzo.somoim.common.annotation;
+
+import com.oinzo.somoim.common.annotation.validator.BirthValidator;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = BirthValidator.class)
+public @interface Birth {
+	String message() default "생년월일을 8자리 숫자로 입력해주세요.";
+	Class[] groups() default {};
+	Class[] payload() default {};
+}

--- a/src/main/java/com/oinzo/somoim/common/annotation/Birth.java
+++ b/src/main/java/com/oinzo/somoim/common/annotation/Birth.java
@@ -11,7 +11,7 @@ import javax.validation.Constraint;
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = BirthValidator.class)
 public @interface Birth {
-	String message() default "생년월일을 8자리 숫자로 입력해주세요.";
+	String message() default "생년월일을 yyyy-mm-dd 형식으로 입력해주세요.";
 	Class[] groups() default {};
 	Class[] payload() default {};
 }

--- a/src/main/java/com/oinzo/somoim/common/annotation/validator/BirthValidator.java
+++ b/src/main/java/com/oinzo/somoim/common/annotation/validator/BirthValidator.java
@@ -13,7 +13,7 @@ public class BirthValidator implements ConstraintValidator<Birth, String> {
 		}
 
 		// 8자리 숫자
-		return value.matches("(19[0-9][0-9]|20\\d{2})(0[0-9]|1[0-2])(0[1-9]|[1-2][0-9]|3[0-1])");
+		return value.matches("(19[0-9][0-9]|20\\d{2})-(0[0-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])");
 	}
 
 }

--- a/src/main/java/com/oinzo/somoim/common/annotation/validator/BirthValidator.java
+++ b/src/main/java/com/oinzo/somoim/common/annotation/validator/BirthValidator.java
@@ -1,0 +1,19 @@
+package com.oinzo.somoim.common.annotation.validator;
+
+import com.oinzo.somoim.common.annotation.Birth;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class BirthValidator implements ConstraintValidator<Birth, String> {
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		if (value == null) {
+			return true;
+		}
+
+		// 8자리 숫자
+		return value.matches("(19[0-9][0-9]|20\\d{2})(0[0-9]|1[0-2])(0[1-9]|[1-2][0-9]|3[0-1])");
+	}
+
+}

--- a/src/main/java/com/oinzo/somoim/common/exception/ErrorCode.java
+++ b/src/main/java/com/oinzo/somoim/common/exception/ErrorCode.java
@@ -11,9 +11,10 @@ public enum ErrorCode {
 	/* 400 Bad Request */
 	INVALID_TOKEN(HttpStatus.BAD_REQUEST, 40002, "잘못된 토큰입니다."),
 	INVALID_KAKAO_CODE(HttpStatus.BAD_REQUEST, 40003, "올바르지 않은 카카오 인가 코드입니다."),
-  NO_SEARCH_NAME(HttpStatus.BAD_REQUEST, 40004, "검색 키워드를 입력해주십시오."),
+  	NO_SEARCH_NAME(HttpStatus.BAD_REQUEST, 40004, "검색 키워드를 입력해주십시오."),
 	WRONG_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, 40007, "입력한 인증번호가 일치하지 않습니다."),
 	WRONG_PASSWORD(HttpStatus.BAD_REQUEST, 40008, "비밀번호 확인이 일치하지 않습니다."),
+	VALIDATION_FAILED(HttpStatus.BAD_REQUEST, 40009, "입력값 유효성 검사에 실패하였습니다."),
 
 	/* 401 Unauthorized */
 	ACCESS_TOKEN_OMISSION(HttpStatus.UNAUTHORIZED, 40101, "인증 정보(액세스 토큰)가 누락되었습니다."),
@@ -21,6 +22,7 @@ public enum ErrorCode {
 	EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 40161, "만료된 리프레쉬 토큰입니다."),
 	LOGOUT_USER(HttpStatus.UNAUTHORIZED, 40162, "로그아웃된 사용자입니다."),
 	WRONG_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 40163, "리프레쉬 토큰 정보가 유효하지 않습니다."),
+
 	/* 403 Forbidden */
 	FORBIDDEN_REQUEST(HttpStatus.FORBIDDEN, 40300, "해당 요청에 대한 권한이 없습니다."),
 

--- a/src/main/java/com/oinzo/somoim/controller/UserController.java
+++ b/src/main/java/com/oinzo/somoim/controller/UserController.java
@@ -1,0 +1,23 @@
+package com.oinzo.somoim.controller;
+
+import com.oinzo.somoim.controller.dto.UserInfoResponse;
+import com.oinzo.somoim.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+	private final UserService userService;
+
+	@GetMapping
+	public UserInfoResponse readUserInfo(@AuthenticationPrincipal Long userId) {
+		return userService.readUserInfo(userId);
+	}
+
+}

--- a/src/main/java/com/oinzo/somoim/controller/UserController.java
+++ b/src/main/java/com/oinzo/somoim/controller/UserController.java
@@ -1,10 +1,14 @@
 package com.oinzo.somoim.controller;
 
+import com.oinzo.somoim.controller.dto.UserInfoRequest;
 import com.oinzo.somoim.controller.dto.UserInfoResponse;
 import com.oinzo.somoim.domain.user.service.UserService;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,6 +22,13 @@ public class UserController {
 	@GetMapping
 	public UserInfoResponse readUserInfo(@AuthenticationPrincipal Long userId) {
 		return userService.readUserInfo(userId);
+	}
+
+	@PostMapping
+	public UserInfoResponse updateUserInfo(
+		@AuthenticationPrincipal Long userId,
+		@RequestBody @Valid UserInfoRequest request) {
+		return userService.updateUserInfo(userId, request);
 	}
 
 }

--- a/src/main/java/com/oinzo/somoim/controller/UserController.java
+++ b/src/main/java/com/oinzo/somoim/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.oinzo.somoim.controller;
 
+import com.oinzo.somoim.controller.dto.FavoriteUpdateRequest;
 import com.oinzo.somoim.controller.dto.UserInfoRequest;
 import com.oinzo.somoim.controller.dto.UserInfoResponse;
 import com.oinzo.somoim.domain.user.service.UserService;
@@ -31,4 +32,10 @@ public class UserController {
 		return userService.updateUserInfo(userId, request);
 	}
 
+	@PostMapping("/favorite")
+	public void updateFavorite(
+		@AuthenticationPrincipal Long userId,
+		@RequestBody @Valid FavoriteUpdateRequest request) {
+		userService.updateFavorite(userId, request.getFavorite());
+	}
 }

--- a/src/main/java/com/oinzo/somoim/controller/dto/FavoriteUpdateRequest.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/FavoriteUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.oinzo.somoim.controller.dto;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FavoriteUpdateRequest {
+
+	@NotBlank
+	private String favorite;
+
+}

--- a/src/main/java/com/oinzo/somoim/controller/dto/UserInfoRequest.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/UserInfoRequest.java
@@ -1,0 +1,27 @@
+package com.oinzo.somoim.controller.dto;
+
+import com.oinzo.somoim.common.annotation.Birth;
+import com.oinzo.somoim.common.type.Favorite;
+import com.oinzo.somoim.common.type.Gender;
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.URL;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserInfoRequest {
+	@NotBlank
+	private String name;
+	@Birth
+	private String birth;
+	private Gender gender;
+	@NotBlank
+	private String area;
+	private String introduction;
+	@URL
+	private String profileUrl;
+}

--- a/src/main/java/com/oinzo/somoim/controller/dto/UserInfoRequest.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/UserInfoRequest.java
@@ -6,11 +6,13 @@ import com.oinzo.somoim.common.type.Gender;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.URL;
 
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserInfoRequest {

--- a/src/main/java/com/oinzo/somoim/controller/dto/UserInfoResponse.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/UserInfoResponse.java
@@ -1,0 +1,33 @@
+package com.oinzo.somoim.controller.dto;
+
+import com.oinzo.somoim.common.type.Gender;
+import com.oinzo.somoim.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserInfoResponse {
+
+	private String name;
+	private String birth;
+	private Gender gender;
+	private String area;
+	private String introduction;
+	private String profileUrl;
+	private String favorite;
+
+	public static UserInfoResponse from(User user) {
+		return UserInfoResponse.builder()
+			.name(user.getName())
+			.birth(user.getBirth())
+			.gender(user.getGender())
+			.area(user.getArea())
+			.introduction(user.getIntroduction())
+			.profileUrl(user.getProfileUrl())
+			.favorite(user.getFavorite())
+			.build();
+	}
+}

--- a/src/main/java/com/oinzo/somoim/controller/dto/UserInfoResponse.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/UserInfoResponse.java
@@ -1,5 +1,6 @@
 package com.oinzo.somoim.controller.dto;
 
+import com.oinzo.somoim.common.type.Favorite;
 import com.oinzo.somoim.common.type.Gender;
 import com.oinzo.somoim.domain.user.entity.User;
 import lombok.AllArgsConstructor;
@@ -17,7 +18,7 @@ public class UserInfoResponse {
 	private String area;
 	private String introduction;
 	private String profileUrl;
-	private String favorite;
+	private Favorite favorite;
 
 	public static UserInfoResponse from(User user) {
 		return UserInfoResponse.builder()

--- a/src/main/java/com/oinzo/somoim/controller/dto/UserInfoResponse.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/UserInfoResponse.java
@@ -3,6 +3,7 @@ package com.oinzo.somoim.controller.dto;
 import com.oinzo.somoim.common.type.Favorite;
 import com.oinzo.somoim.common.type.Gender;
 import com.oinzo.somoim.domain.user.entity.User;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import lombok.Getter;
 public class UserInfoResponse {
 
 	private String name;
-	private String birth;
+	private LocalDate birth;
 	private Gender gender;
 	private String area;
 	private String introduction;

--- a/src/main/java/com/oinzo/somoim/domain/user/entity/User.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/entity/User.java
@@ -75,4 +75,8 @@ public class User extends BaseEntity {
 		this.introduction = request.getIntroduction();
 		this.profileUrl = request.getProfileUrl();
 	}
+
+	public void updateFavorite(Favorite favorite) {
+		this.favorite = favorite;
+	}
 }

--- a/src/main/java/com/oinzo/somoim/domain/user/entity/User.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/entity/User.java
@@ -4,6 +4,7 @@ import com.oinzo.somoim.common.entity.BaseEntity;
 import com.oinzo.somoim.common.type.Favorite;
 import com.oinzo.somoim.common.type.Gender;
 import com.oinzo.somoim.common.type.SocialType;
+import com.oinzo.somoim.controller.dto.UserInfoRequest;
 import com.oinzo.somoim.domain.user.dto.GoogleUserInfoDto;
 import com.oinzo.somoim.domain.user.dto.KakaoUserInfoDto;
 import javax.persistence.Entity;
@@ -62,5 +63,15 @@ public class User extends BaseEntity {
 			.name(googleUserInfoDto.getName())
 			.profileUrl(googleUserInfoDto.getProfileUrl())
 			.build();
+	}
+
+	public void updateUserInfo(UserInfoRequest request) {
+		this.name = request.getName();
+		this.area = request.getArea();
+		this.birth = request.getBirth();
+		this.gender = request.getGender();
+		this.area = request.getArea();
+		this.introduction = request.getIntroduction();
+		this.profileUrl = request.getProfileUrl();
 	}
 }

--- a/src/main/java/com/oinzo/somoim/domain/user/entity/User.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.oinzo.somoim.domain.user.entity;
 
 import com.oinzo.somoim.common.entity.BaseEntity;
+import com.oinzo.somoim.common.type.Favorite;
 import com.oinzo.somoim.common.type.Gender;
 import com.oinzo.somoim.common.type.SocialType;
 import com.oinzo.somoim.domain.user.dto.GoogleUserInfoDto;
@@ -34,7 +35,8 @@ public class User extends BaseEntity {
 	private String area;
 	private String introduction;
 	private String profileUrl;
-	private String favorite;
+	@Enumerated(value = EnumType.STRING)
+	private Favorite favorite;
 
 	private String email;
 	private String password;

--- a/src/main/java/com/oinzo/somoim/domain/user/entity/User.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/entity/User.java
@@ -7,6 +7,7 @@ import com.oinzo.somoim.common.type.SocialType;
 import com.oinzo.somoim.controller.dto.UserInfoRequest;
 import com.oinzo.somoim.domain.user.dto.GoogleUserInfoDto;
 import com.oinzo.somoim.domain.user.dto.KakaoUserInfoDto;
+import java.time.LocalDate;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -30,7 +31,7 @@ public class User extends BaseEntity {
 	private Long id;
 
 	private String name;
-	private String birth;
+	private LocalDate birth;
 	@Enumerated(value = EnumType.STRING)
 	private Gender gender;
 	private String area;
@@ -68,7 +69,7 @@ public class User extends BaseEntity {
 	public void updateUserInfo(UserInfoRequest request) {
 		this.name = request.getName();
 		this.area = request.getArea();
-		this.birth = request.getBirth();
+		this.birth = LocalDate.parse(request.getBirth());
 		this.gender = request.getGender();
 		this.area = request.getArea();
 		this.introduction = request.getIntroduction();

--- a/src/main/java/com/oinzo/somoim/domain/user/service/UserService.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/service/UserService.java
@@ -35,10 +35,11 @@ public class UserService {
 	}
 
 	public void updateFavorite(Long userId, String favorteString) {
+		Favorite favorite = Favorite.valueOfOrHandleException(favorteString);
+
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND, "userId=" + userId));
 
-		Favorite favorite = Favorite.valueOfOrHandleException(favorteString);
 		user.updateFavorite(favorite);
 		userRepository.save(user);
 	}

--- a/src/main/java/com/oinzo/somoim/domain/user/service/UserService.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/service/UserService.java
@@ -1,0 +1,25 @@
+package com.oinzo.somoim.domain.user.service;
+
+import com.oinzo.somoim.common.exception.BaseException;
+import com.oinzo.somoim.common.exception.ErrorCode;
+import com.oinzo.somoim.controller.dto.UserInfoResponse;
+import com.oinzo.somoim.domain.user.entity.User;
+import com.oinzo.somoim.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+
+	private final UserRepository userRepository;
+
+
+	public UserInfoResponse readUserInfo(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND, "userId=" + userId));
+
+		return UserInfoResponse.from(user);
+
+	}
+}

--- a/src/main/java/com/oinzo/somoim/domain/user/service/UserService.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.oinzo.somoim.domain.user.service;
 
 import com.oinzo.somoim.common.exception.BaseException;
 import com.oinzo.somoim.common.exception.ErrorCode;
+import com.oinzo.somoim.common.type.Favorite;
 import com.oinzo.somoim.controller.dto.UserInfoRequest;
 import com.oinzo.somoim.controller.dto.UserInfoResponse;
 import com.oinzo.somoim.domain.user.entity.User;
@@ -31,5 +32,14 @@ public class UserService {
 		user.updateUserInfo(request);
 		User savedUser = userRepository.save(user);
 		return UserInfoResponse.from(savedUser);
+	}
+
+	public void updateFavorite(Long userId, String favorteString) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND, "userId=" + userId));
+
+		Favorite favorite = Favorite.valueOfOrHandleException(favorteString);
+		user.updateFavorite(favorite);
+		userRepository.save(user);
 	}
 }

--- a/src/main/java/com/oinzo/somoim/domain/user/service/UserService.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.oinzo.somoim.domain.user.service;
 
 import com.oinzo.somoim.common.exception.BaseException;
 import com.oinzo.somoim.common.exception.ErrorCode;
+import com.oinzo.somoim.controller.dto.UserInfoRequest;
 import com.oinzo.somoim.controller.dto.UserInfoResponse;
 import com.oinzo.somoim.domain.user.entity.User;
 import com.oinzo.somoim.domain.user.repository.UserRepository;
@@ -21,5 +22,14 @@ public class UserService {
 
 		return UserInfoResponse.from(user);
 
+	}
+
+	public UserInfoResponse updateUserInfo(Long userId, UserInfoRequest request) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND, "userId=" + userId));
+
+		user.updateUserInfo(request);
+		User savedUser = userRepository.save(user);
+		return UserInfoResponse.from(savedUser);
 	}
 }

--- a/src/test/java/com/oinzo/somoim/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/oinzo/somoim/domain/user/service/UserServiceTest.java
@@ -1,17 +1,24 @@
 package com.oinzo.somoim.domain.user.service;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.oinzo.somoim.common.type.Favorite;
 import com.oinzo.somoim.common.type.Gender;
+import com.oinzo.somoim.controller.dto.UserInfoRequest;
 import com.oinzo.somoim.controller.dto.UserInfoResponse;
 import com.oinzo.somoim.domain.user.entity.User;
 import com.oinzo.somoim.domain.user.repository.UserRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalAnswers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -52,4 +59,42 @@ class UserServiceTest {
 		assertEquals("GAME", response.getFavorite().name());
 	}
 
+	@Test
+	public void testUpdateUserInfo() {
+		// given
+		User mockUser = User.builder()
+			.id(1L)
+			.name("홍길동")
+			.birth("20000101")
+			.gender(Gender.MALE)
+			.area("서울")
+			.introduction("자기소개입니다")
+			.favorite(Favorite.GAME)
+			.build();
+		given(userRepository.findById(anyLong()))
+			.willReturn(Optional.of(mockUser));
+		when(userRepository.save(any(User.class)))
+			.then(AdditionalAnswers.returnsFirstArg());
+
+		ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+
+		// when
+		UserInfoRequest request = UserInfoRequest.builder()
+			.name("홈런볼")
+			.birth("19991212")
+			.gender(Gender.FEMALE)
+			.area("인천")
+			.introduction("레몬사탕")
+			.build();
+		userService.updateUserInfo(1L, request);
+
+		// then
+		verify(userRepository, times(1)).save(captor.capture());
+		User capturedUser = captor.getValue();
+		assertEquals("홈런볼", capturedUser.getName());
+		assertEquals("19991212", capturedUser.getBirth());
+		assertEquals(Gender.FEMALE, capturedUser.getGender());
+		assertEquals("인천", capturedUser.getArea());
+		assertEquals("레몬사탕", capturedUser.getIntroduction());
+	}
 }

--- a/src/test/java/com/oinzo/somoim/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/oinzo/somoim/domain/user/service/UserServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.oinzo.somoim.common.exception.BaseException;
+import com.oinzo.somoim.common.exception.ErrorCode;
 import com.oinzo.somoim.common.type.Favorite;
 import com.oinzo.somoim.common.type.Gender;
 import com.oinzo.somoim.controller.dto.UserInfoRequest;
@@ -97,5 +99,41 @@ class UserServiceTest {
 		assertEquals(Gender.FEMALE, capturedUser.getGender());
 		assertEquals("인천", capturedUser.getArea());
 		assertEquals("레몬사탕", capturedUser.getIntroduction());
+	}
+
+	@Test
+	public void testUpdateFavorite() {
+		// given
+		User mockUser = User.builder()
+			.id(1L)
+			.build();
+		given(userRepository.findById(anyLong()))
+			.willReturn(Optional.of(mockUser));
+
+		ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+
+		// when
+		userService.updateFavorite(1L, "GAME");
+
+		// then
+		verify(userRepository, times(1)).save(captor.capture());
+		assertEquals("GAME", captor.getValue().getFavorite().toString());
+	}
+
+	@Test
+	public void testUpdateFavorite_wrongFavorite() {
+		// given
+		User mockUser = User.builder()
+			.id(1L)
+			.build();
+		given(userRepository.findById(anyLong()))
+			.willReturn(Optional.of(mockUser));
+
+		// when
+		BaseException exception = assertThrows(BaseException.class,
+			() -> userService.updateFavorite(1L, "WRONG_FAVORITE"));
+
+		// then
+		assertEquals(ErrorCode.WRONG_FAVORITE, exception.getErrorCode());
 	}
 }

--- a/src/test/java/com/oinzo/somoim/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/oinzo/somoim/domain/user/service/UserServiceTest.java
@@ -1,0 +1,55 @@
+package com.oinzo.somoim.domain.user.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.oinzo.somoim.common.type.Favorite;
+import com.oinzo.somoim.common.type.Gender;
+import com.oinzo.somoim.controller.dto.UserInfoResponse;
+import com.oinzo.somoim.domain.user.entity.User;
+import com.oinzo.somoim.domain.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+	@InjectMocks
+	UserService userService;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Test
+	public void testReadUserInfo() {
+		// given
+		User mockUser = User.builder()
+			.id(1L)
+			.name("홍길동")
+			.birth("20000101")
+			.gender(Gender.MALE)
+			.area("서울")
+			.introduction("자기소개입니다")
+			.favorite(Favorite.GAME)
+			.build();
+		given(userRepository.findById(anyLong()))
+			.willReturn(Optional.of(mockUser));
+
+		// when
+		UserInfoResponse response = userService.readUserInfo(1L);
+
+		// then
+		assertEquals("홍길동", response.getName());
+		assertEquals("20000101", response.getBirth());
+		assertEquals("MALE", response.getGender().name());
+		assertEquals("서울", response.getArea());
+		assertEquals("자기소개입니다", response.getIntroduction());
+		assertEquals("GAME", response.getFavorite().name());
+	}
+
+}

--- a/src/test/java/com/oinzo/somoim/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/oinzo/somoim/domain/user/service/UserServiceTest.java
@@ -14,6 +14,7 @@ import com.oinzo.somoim.controller.dto.UserInfoRequest;
 import com.oinzo.somoim.controller.dto.UserInfoResponse;
 import com.oinzo.somoim.domain.user.entity.User;
 import com.oinzo.somoim.domain.user.repository.UserRepository;
+import java.time.LocalDate;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +39,7 @@ class UserServiceTest {
 		User mockUser = User.builder()
 			.id(1L)
 			.name("홍길동")
-			.birth("20000101")
+			.birth(LocalDate.parse("2000-01-01"))
 			.gender(Gender.MALE)
 			.area("서울")
 			.introduction("자기소개입니다")
@@ -52,7 +53,7 @@ class UserServiceTest {
 
 		// then
 		assertEquals("홍길동", response.getName());
-		assertEquals("20000101", response.getBirth());
+		assertEquals("2000-01-01", response.getBirth().toString());
 		assertEquals("MALE", response.getGender().name());
 		assertEquals("서울", response.getArea());
 		assertEquals("자기소개입니다", response.getIntroduction());
@@ -65,7 +66,7 @@ class UserServiceTest {
 		User mockUser = User.builder()
 			.id(1L)
 			.name("홍길동")
-			.birth("20000101")
+			.birth(LocalDate.parse("2000-01-01"))
 			.gender(Gender.MALE)
 			.area("서울")
 			.introduction("자기소개입니다")
@@ -81,7 +82,7 @@ class UserServiceTest {
 		// when
 		UserInfoRequest request = UserInfoRequest.builder()
 			.name("홈런볼")
-			.birth("19991212")
+			.birth("1999-12-12")
 			.gender(Gender.FEMALE)
 			.area("인천")
 			.introduction("레몬사탕")
@@ -92,7 +93,7 @@ class UserServiceTest {
 		verify(userRepository, times(1)).save(captor.capture());
 		User capturedUser = captor.getValue();
 		assertEquals("홈런볼", capturedUser.getName());
-		assertEquals("19991212", capturedUser.getBirth());
+		assertEquals("1999-12-12", capturedUser.getBirth().toString());
 		assertEquals(Gender.FEMALE, capturedUser.getGender());
 		assertEquals("인천", capturedUser.getArea());
 		assertEquals("레몬사탕", capturedUser.getIntroduction());


### PR DESCRIPTION
## 구현 내용
회원정보 조회 API, 관심사를 제외한 회원정보 수정 API, 관심사 수정 API를 작성하였습니다.
이 과정에서 User 엔티티의 필드 타입 변경이 있었습니다.
- 생년월일: String -> LocalDate (DB도 이와 맞게 형식을 바꾸었습니다.)
- Favorite: String -> Favorite 
생년월일은 yyyy-mm-dd 형식으로 받기 위해 Custom Validation Annotation을 작성하였습니다.
<br>

## 관련 이슈
- #16

<br>

## 중점적으로 봐줬으면 하는 부분
엔티티 필드 타입 변경한 부분에 대해 자세히 봐주셨으면 좋겠습니다.