### PR TITLE
refactor: 클럽 가입 과정에서 DB 호출 최소화 (#30)

### DIFF
--- a/src/main/java/com/oinzo/somoim/domain/clubuser/entity/ClubUser.java
+++ b/src/main/java/com/oinzo/somoim/domain/clubuser/entity/ClubUser.java
@@ -1,5 +1,7 @@
 package com.oinzo.somoim.domain.clubuser.entity;
 
+import static javax.persistence.FetchType.LAZY;
+
 import com.oinzo.somoim.common.entity.BaseEntity;
 import com.oinzo.somoim.common.type.ClubUserLevel;
 import com.oinzo.somoim.domain.club.entity.Club;
@@ -30,11 +32,11 @@ public class ClubUser extends BaseEntity {
 	private ClubUserLevel level;
 	private String introduction;
 
-	@ManyToOne
+	@ManyToOne(fetch = LAZY)
 	@JoinColumn
 	private User user;
 
-	@ManyToOne
+	@ManyToOne(fetch = LAZY)
 	@JoinColumn
 	private Club club;
 

--- a/src/main/java/com/oinzo/somoim/domain/clubuser/repository/ClubUserRepository.java
+++ b/src/main/java/com/oinzo/somoim/domain/clubuser/repository/ClubUserRepository.java
@@ -1,14 +1,12 @@
 package com.oinzo.somoim.domain.clubuser.repository;
 
-import com.oinzo.somoim.domain.club.entity.Club;
 import com.oinzo.somoim.domain.clubuser.entity.ClubUser;
-import com.oinzo.somoim.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ClubUserRepository extends JpaRepository<ClubUser, Long> {
 
-	Boolean existsByUserAndClub(User user, Club club);
+	Boolean existsByUser_IdAndClub_Id(Long userId, Long clubId);
 
 }

--- a/src/main/java/com/oinzo/somoim/domain/clubuser/service/ClubUserService.java
+++ b/src/main/java/com/oinzo/somoim/domain/clubuser/service/ClubUserService.java
@@ -23,16 +23,14 @@ public class ClubUserService {
 
 	@Transactional
 	public void joinClub(Long userId, Long clubId, String introduction) {
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND, "userId=" + userId));
+		// 이미 가입된 회원인지 확인
+		if (clubUserRepository.existsByUser_IdAndClub_Id(userId, clubId)) {
+			throw new BaseException(ErrorCode.ALREADY_CLUB_MEMBER,
+				"userId=" + userId + ", clubId=" + clubId);
+		}
+
 		Club club = clubRepository.findById(clubId)
 			.orElseThrow(() -> new BaseException(ErrorCode.WRONG_CLUB, "clubId=" + clubId));
-
-		// 이미 가입된 회원인지 확인
-		if (clubUserRepository.existsByUserAndClub(user, club)) {
-			throw new BaseException(ErrorCode.ALREADY_CLUB_MEMBER,
-				"userId=" + userId + ", clubId" + clubId);
-		}
 
 		// 멤버 정원이 꽉 찼는지 확인
 		if (club.getMemberLimit() == club.getMemberCnt()) {
@@ -41,6 +39,8 @@ public class ClubUserService {
 		}
 
 		// 클럽 멤버로 등록
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND, "userId=" + userId));
 		ClubUser clubUser = ClubUser.createClubUser(user, club, introduction);
 		clubUserRepository.save(clubUser);
 	}

--- a/src/main/java/com/oinzo/somoim/domain/user/service/UserService.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/service/UserService.java
@@ -22,7 +22,6 @@ public class UserService {
 			.orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND, "userId=" + userId));
 
 		return UserInfoResponse.from(user);
-
 	}
 
 	public UserInfoResponse updateUserInfo(Long userId, UserInfoRequest request) {

--- a/src/test/java/com/oinzo/somoim/domain/clubuser/service/ClubUserServiceTest.java
+++ b/src/test/java/com/oinzo/somoim/domain/clubuser/service/ClubUserServiceTest.java
@@ -2,7 +2,6 @@ package com.oinzo.somoim.domain.clubuser.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -56,12 +55,12 @@ class ClubUserServiceTest {
 			.memberCnt(0)
 			.favorite(Favorite.GAME)
 			.build();
-		given(userRepository.findById(anyLong()))
-			.willReturn(Optional.of(mockUser));
+		given(clubUserRepository.existsByUser_IdAndClub_Id(anyLong(), anyLong()))
+			.willReturn(false);
 		given(clubRepository.findById(anyLong()))
 			.willReturn(Optional.of(mockClub));
-		given(clubUserRepository.existsByUserAndClub(any(), any()))
-			.willReturn(false);
+		given(userRepository.findById(anyLong()))
+			.willReturn(Optional.of(mockUser));
 
 		ArgumentCaptor<ClubUser> captor = ArgumentCaptor.forClass(ClubUser.class);
 
@@ -81,9 +80,6 @@ class ClubUserServiceTest {
 	@Test
 	void testJoinClub_memberLimitOver() {
 		// given
-		User mockUser = User.builder()
-			.id(1L)
-			.build();
 		Club mockClub = Club.builder()
 			.id(1L)
 			.name("게임 클럽")
@@ -93,12 +89,10 @@ class ClubUserServiceTest {
 			.memberCnt(1)
 			.favorite(Favorite.GAME)
 			.build();
-		given(userRepository.findById(anyLong()))
-			.willReturn(Optional.of(mockUser));
+		given(clubUserRepository.existsByUser_IdAndClub_Id(anyLong(), anyLong()))
+			.willReturn(false);
 		given(clubRepository.findById(anyLong()))
 			.willReturn(Optional.of(mockClub));
-		given(clubUserRepository.existsByUserAndClub(any(), any()))
-			.willReturn(false);
 
 		// when
 		String introduction = "안녕하세요 게임 클럽에 가입합니다.";
@@ -112,23 +106,7 @@ class ClubUserServiceTest {
 	@Test
 	void testJoinClub_alreadyMember() {
 		// given
-		User mockUser = User.builder()
-			.id(1L)
-			.build();
-		Club mockClub = Club.builder()
-			.id(1L)
-			.name("게임 클럽")
-			.description("열정맨 게임 클럽입니다.")
-			.area("청파동")
-			.memberLimit(5)
-			.memberCnt(1)
-			.favorite(Favorite.GAME)
-			.build();
-		given(userRepository.findById(anyLong()))
-			.willReturn(Optional.of(mockUser));
-		given(clubRepository.findById(anyLong()))
-			.willReturn(Optional.of(mockClub));
-		given(clubUserRepository.existsByUserAndClub(any(), any()))
+		given(clubUserRepository.existsByUser_IdAndClub_Id(anyLong(), anyLong()))
 			.willReturn(true);
 
 		// when


### PR DESCRIPTION
## 구현 내용
- Club, User의 fecth를 지연로딩(LAZY)으로 설정
- DB 호출을 최소화하기 위해 가능한 유효성 검사 모두 진행 후 Club 또는 User 객체 조회
<br>

## 관련 이슈
- #30


