### PR TITLE
fix: 대소문자 상관없이 관심사 매핑하도록 수정 (#41)

### DIFF
--- a/src/main/java/com/oinzo/somoim/common/type/Favorite.java
+++ b/src/main/java/com/oinzo/somoim/common/type/Favorite.java
@@ -26,7 +26,8 @@ public enum Favorite {
 
     public static Favorite valueOfOrHandleException(String string) {
         try {
-            return Favorite.valueOf(string);
+            String treatedString = string.trim().toUpperCase();
+            return Favorite.valueOf(treatedString);
         } catch (IllegalArgumentException e)  {
             throw new BaseException(ErrorCode.WRONG_FAVORITE, "favorite=" + string);
         }


### PR DESCRIPTION
## 구현 내용
현재 대문자로 된 관심사만 enum으로 매핑되고 있어 대소문자 모두 매핑될 수 있도록 코드를 수정하였습니다.
trim()을 사용해 앞뒤 공백 제거하고, toUpperCase()를 사용해 모든 문자를 대문자로 만든 뒤 관심사와 매핑합니다.
<br>

## 관련 이슈
- #41

