### PR TITLE
fix: 사용자 관심사를 여러 개 설정 가능하도록 변경 (#43)

### DIFF
--- a/src/main/java/com/oinzo/somoim/controller/UserController.java
+++ b/src/main/java/com/oinzo/somoim/controller/UserController.java
@@ -40,7 +40,7 @@ public class UserController {
 	public SuccessResponse<?> updateFavorite(
 		@AuthenticationPrincipal Long userId,
 		@RequestBody @Valid FavoriteUpdateRequest request) {
-		userService.updateFavorite(userId, request.getFavorite());
+		userService.updateFavorite(userId, request.getFavorites());
 		return ResponseUtil.success();
 	}
 }

--- a/src/main/java/com/oinzo/somoim/controller/dto/FavoriteUpdateRequest.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/FavoriteUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.oinzo.somoim.controller.dto;
 
-import javax.validation.constraints.NotBlank;
+import java.util.List;
+import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FavoriteUpdateRequest {
 
-	@NotBlank
-	private String favorite;
+	@NotNull
+	private List<String> favorites;
 
 }

--- a/src/main/java/com/oinzo/somoim/controller/dto/UserInfoResponse.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/UserInfoResponse.java
@@ -4,6 +4,7 @@ import com.oinzo.somoim.common.type.Favorite;
 import com.oinzo.somoim.common.type.Gender;
 import com.oinzo.somoim.domain.user.entity.User;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +20,7 @@ public class UserInfoResponse {
 	private String area;
 	private String introduction;
 	private String profileUrl;
-	private Favorite favorite;
+	private List<Favorite> favorites;
 
 	public static UserInfoResponse from(User user) {
 		return UserInfoResponse.builder()
@@ -29,7 +30,7 @@ public class UserInfoResponse {
 			.area(user.getArea())
 			.introduction(user.getIntroduction())
 			.profileUrl(user.getProfileUrl())
-			.favorite(user.getFavorite())
+			.favorites(user.getFavorites())
 			.build();
 	}
 }

--- a/src/main/java/com/oinzo/somoim/domain/user/entity/FavoriteListConverter.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/entity/FavoriteListConverter.java
@@ -1,0 +1,30 @@
+package com.oinzo.somoim.domain.user.entity;
+
+import com.oinzo.somoim.common.type.Favorite;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.AttributeConverter;
+
+public class FavoriteListConverter implements AttributeConverter<List<Favorite>, String> {
+	private static final String SPLIT_CHAR = ";";
+
+	@Override
+	public String convertToDatabaseColumn(List<Favorite> favorites) {
+		StringBuilder sb = new StringBuilder();
+		for (Favorite favorite : favorites) {
+			sb.append(favorite.name());
+			sb.append(SPLIT_CHAR);
+		}
+		sb.deleteCharAt(sb.length() - 1);
+		System.out.println("sb = " + sb);
+		return sb.toString();
+	}
+
+	@Override
+	public List<Favorite> convertToEntityAttribute(String string) {
+		return Arrays.stream(string.split(SPLIT_CHAR))
+			.map(Favorite::valueOfOrHandleException)
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/oinzo/somoim/domain/user/entity/User.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/entity/User.java
@@ -8,6 +8,9 @@ import com.oinzo.somoim.controller.dto.UserInfoRequest;
 import com.oinzo.somoim.domain.user.dto.GoogleUserInfoDto;
 import com.oinzo.somoim.domain.user.dto.KakaoUserInfoDto;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -37,8 +40,9 @@ public class User extends BaseEntity {
 	private String area;
 	private String introduction;
 	private String profileUrl;
-	@Enumerated(value = EnumType.STRING)
-	private Favorite favorite;
+
+	@Convert(converter = FavoriteListConverter.class)
+	private List<Favorite> favorites;
 
 	private String email;
 	private String password;
@@ -76,7 +80,7 @@ public class User extends BaseEntity {
 		this.profileUrl = request.getProfileUrl();
 	}
 
-	public void updateFavorite(Favorite favorite) {
-		this.favorite = favorite;
+	public void updateFavorites(List<Favorite> favorites) {
+		this.favorites = favorites;
 	}
 }

--- a/src/main/java/com/oinzo/somoim/domain/user/service/UserService.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/service/UserService.java
@@ -7,6 +7,9 @@ import com.oinzo.somoim.controller.dto.UserInfoRequest;
 import com.oinzo.somoim.controller.dto.UserInfoResponse;
 import com.oinzo.somoim.domain.user.entity.User;
 import com.oinzo.somoim.domain.user.repository.UserRepository;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -33,13 +36,15 @@ public class UserService {
 		return UserInfoResponse.from(savedUser);
 	}
 
-	public void updateFavorite(Long userId, String favoriteString) {
-		Favorite favorite = Favorite.valueOfOrHandleException(favoriteString);
+	public void updateFavorite(Long userId, List<String> favoriteStrings) {
+		List<Favorite> favorites = favoriteStrings.stream()
+			.map(Favorite::valueOfOrHandleException)
+			.collect(Collectors.toList());
 
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND, "userId=" + userId));
 
-		user.updateFavorite(favorite);
+		user.updateFavorites(favorites);
 		userRepository.save(user);
 	}
 }

--- a/src/test/java/com/oinzo/somoim/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/oinzo/somoim/domain/user/service/UserServiceTest.java
@@ -17,6 +17,7 @@ import com.oinzo.somoim.controller.dto.UserInfoResponse;
 import com.oinzo.somoim.domain.user.entity.User;
 import com.oinzo.somoim.domain.user.repository.UserRepository;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,7 +46,7 @@ class UserServiceTest {
 			.gender(Gender.MALE)
 			.area("서울")
 			.introduction("자기소개입니다")
-			.favorite(Favorite.GAME)
+			.favorites(List.of(Favorite.GAME, Favorite.PICTURE))
 			.build();
 		given(userRepository.findById(anyLong()))
 			.willReturn(Optional.of(mockUser));
@@ -59,7 +60,9 @@ class UserServiceTest {
 		assertEquals("MALE", response.getGender().name());
 		assertEquals("서울", response.getArea());
 		assertEquals("자기소개입니다", response.getIntroduction());
-		assertEquals("GAME", response.getFavorite().name());
+		assertEquals(2, response.getFavorites().size());
+		assertTrue(response.getFavorites().contains(Favorite.GAME));
+		assertTrue(response.getFavorites().contains(Favorite.PICTURE));
 	}
 
 	@Test
@@ -72,7 +75,7 @@ class UserServiceTest {
 			.gender(Gender.MALE)
 			.area("서울")
 			.introduction("자기소개입니다")
-			.favorite(Favorite.GAME)
+			.favorites(List.of(Favorite.GAME, Favorite.PICTURE))
 			.build();
 		given(userRepository.findById(anyLong()))
 			.willReturn(Optional.of(mockUser));
@@ -113,11 +116,14 @@ class UserServiceTest {
 		ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
 
 		// when
-		userService.updateFavorite(1L, "GAME");
+		userService.updateFavorite(1L, List.of("GAME", "PICTURE"));
 
 		// then
 		verify(userRepository, times(1)).save(captor.capture());
-		assertEquals("GAME", captor.getValue().getFavorite().toString());
+		List<Favorite> favorites = captor.getValue().getFavorites();
+		assertEquals(2, favorites.size());
+		assertTrue(favorites.contains(Favorite.GAME));
+		assertTrue(favorites.contains(Favorite.PICTURE));
 	}
 
 	@Test
@@ -125,7 +131,7 @@ class UserServiceTest {
 		// given
 		// when
 		BaseException exception = assertThrows(BaseException.class,
-			() -> userService.updateFavorite(1L, "WRONG_FAVORITE"));
+			() -> userService.updateFavorite(1L, List.of("WRONG_FAVORITE")));
 
 		// then
 		assertEquals(ErrorCode.WRONG_FAVORITE, exception.getErrorCode());


### PR DESCRIPTION
## 구현 내용
사용자 관심사를 여러 개 설정할 수 있도록 코드를 수정했습니다.
<br>

## 관련 이슈
- #43

<br>

## 중점적으로 봐줬으면 하는 부분
- FavoriteUpdateRequest, UserInfoResponse의 관심사 필드를 List 형태로 변경했습니다.
- User 엔티티의 관심사 컬럼을 List<Favorite>으로 변경 후 DB에는 String으로 저장할 수 있도록 FavoriteListConverter를 작성하고 이를 컨버터로 지정했습니다.
- 관련된 테스트 코드를 수정했습니다.