### PR TITLE
Feat/40 board comment

### DIFF
--- a/src/main/java/com/oinzo/somoim/common/exception/ErrorCode.java
+++ b/src/main/java/com/oinzo/somoim/common/exception/ErrorCode.java
@@ -12,7 +12,7 @@ public enum ErrorCode {
 	INVALID_TOKEN(HttpStatus.BAD_REQUEST, 40002, "잘못된 토큰입니다."),
 	INVALID_KAKAO_CODE(HttpStatus.BAD_REQUEST, 40003, "올바르지 않은 카카오 인가 코드입니다."),
 
-    NO_SEARCH_NAME(HttpStatus.BAD_REQUEST, 40004, "검색 키워드를 입력해주십시오."),
+	NO_SEARCH_NAME(HttpStatus.BAD_REQUEST, 40004, "검색 키워드를 입력해주십시오."),
 	CLUB_LIMIT_OVER(HttpStatus.BAD_REQUEST, 40005, "해당 클럽의 멤버 정원이 다 찼습니다."),
 	ALREADY_CLUB_MEMBER(HttpStatus.BAD_REQUEST, 40006, "이미 해당 클럽의 멤버입니다."),
 	WRONG_PASSWORD(HttpStatus.BAD_REQUEST, 40008, "비밀번호가 일치하지 않습니다."),
@@ -22,6 +22,7 @@ public enum ErrorCode {
 	/* 401 Unauthorized */
 	ACCESS_TOKEN_OMISSION(HttpStatus.UNAUTHORIZED, 40101, "인증 정보(액세스 토큰)가 누락되었습니다."),
 	EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, 40103, "만료된 액세스 토큰입니다."),
+	NOT_CLUB_MEMBER(HttpStatus.NOT_FOUND, 40130, "클럽에 가입후 이용 가능합니다."),
 	EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 40161, "만료된 리프레쉬 토큰입니다."),
 	LOGOUT_USER(HttpStatus.UNAUTHORIZED, 40162, "로그아웃된 사용자입니다."),
 	WRONG_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 40163, "리프레쉬 토큰 정보가 유효하지 않습니다."),
@@ -31,11 +32,12 @@ public enum ErrorCode {
 
 	/* 404 Not Found */
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, 40401, "사용자를 찾을 수 없습니다."),
-  	NO_DATA_FOUND(HttpStatus.NOT_FOUND, 40402, "해당하는 데이터를 찾을 수 없습니다."),
+	NO_DATA_FOUND(HttpStatus.NOT_FOUND, 40402, "해당하는 데이터를 찾을 수 없습니다."),
 	WRONG_CLUB(HttpStatus.NOT_FOUND, 40403, "해당하는 클럽을 찾을 수 없습니다."),
 	WRONG_FAVORITE(HttpStatus.NOT_FOUND, 40404, "해당하는 관심사를 찾을 수 없습니다."),
 	WRONG_BOARD(HttpStatus.NOT_FOUND, 40430, "해당하는 게시글을 찾을 수 없습니다."),
 	WRONG_CATEGORY(HttpStatus.NOT_FOUND, 40431, "해당하는 카테고리를 찾을 수 없습니다."),
+	WRONG_COMMENT(HttpStatus.NOT_FOUND, 40432, "해당하는 댓글을 찾을 수 없습니다."),
 
 	/* 409 Conflict */
 	ALREADY_EXISTS_EMAIL(HttpStatus.CONFLICT, 40901, "이미 가입된 이메일 입니다."),
@@ -51,3 +53,4 @@ public enum ErrorCode {
 	private final int code;
 	private final String message;
 }
+

--- a/src/main/java/com/oinzo/somoim/common/type/Category.java
+++ b/src/main/java/com/oinzo/somoim/common/type/Category.java
@@ -5,11 +5,11 @@ import com.oinzo.somoim.common.exception.ErrorCode;
 
 public enum Category {
 
-    자유,
-    관심사,
-    정모,
-    가입,
-    공지;
+    FREE,
+    FAVORITE,
+    MEET,
+    JOIN,
+    ANNOUCEMENT;
 
     public static Category valueOfOrHandleException(String string) {
         try {

--- a/src/main/java/com/oinzo/somoim/controller/BoardCommentController.java
+++ b/src/main/java/com/oinzo/somoim/controller/BoardCommentController.java
@@ -1,0 +1,57 @@
+package com.oinzo.somoim.controller;
+
+import com.oinzo.somoim.common.response.ResponseUtil;
+import com.oinzo.somoim.common.response.SuccessResponse;
+import com.oinzo.somoim.controller.dto.CommentRequest;
+import com.oinzo.somoim.controller.dto.CommentResponse;
+import com.oinzo.somoim.domain.boardcomment.service.BoardCommentService;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/boards")
+public class BoardCommentController {
+
+    private final BoardCommentService boardCommentService;
+
+    @PostMapping("/{boardId}/comments")
+    public SuccessResponse<CommentResponse> addComment(@PathVariable Long boardId,
+                                                       @RequestBody CommentRequest request,
+                                                       @AuthenticationPrincipal Long userId){
+        CommentResponse response = boardCommentService.addComment(request,boardId,userId);
+        return ResponseUtil.success(response);
+    }
+
+    @GetMapping("/comments/{commentId}")
+    public SuccessResponse<CommentResponse> readOneComment(@PathVariable Long commentId,
+                                                           @AuthenticationPrincipal Long userId){
+        CommentResponse response = boardCommentService.readOneComment(commentId,userId);
+        return ResponseUtil.success(response);
+    }
+
+    @GetMapping("/{boardId}/comments")
+    public SuccessResponse<List<CommentResponse>> readAllComment(@PathVariable Long boardId,
+                                                                 @AuthenticationPrincipal Long userId){
+        List<CommentResponse> response = boardCommentService.readAllComment(boardId,userId);
+        return ResponseUtil.success(response);
+    }
+
+    @PatchMapping("/comments/{commentId}")
+    public SuccessResponse<CommentResponse> updateComment(@PathVariable Long commentId,
+                                                          @RequestBody CommentRequest request,
+                                                          @AuthenticationPrincipal Long userId){
+        CommentResponse response = boardCommentService.updateComment(request,commentId,userId);
+        return ResponseUtil.success(response);
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public SuccessResponse<?> deleteComment(@PathVariable Long commentId,
+                                            @AuthenticationPrincipal Long userId){
+        boardCommentService.deleteComment(commentId,userId);
+        return ResponseUtil.success();
+    }
+}

--- a/src/main/java/com/oinzo/somoim/controller/BoardCommentController.java
+++ b/src/main/java/com/oinzo/somoim/controller/BoardCommentController.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -20,7 +21,7 @@ public class BoardCommentController {
 
     @PostMapping("/{boardId}/comments")
     public SuccessResponse<CommentResponse> addComment(@PathVariable Long boardId,
-                                                       @RequestBody CommentRequest request,
+                                                       @Valid @RequestBody CommentRequest request,
                                                        @AuthenticationPrincipal Long userId){
         CommentResponse response = boardCommentService.addComment(request,boardId,userId);
         return ResponseUtil.success(response);

--- a/src/main/java/com/oinzo/somoim/controller/BoardCommentController.java
+++ b/src/main/java/com/oinzo/somoim/controller/BoardCommentController.java
@@ -20,38 +20,43 @@ public class BoardCommentController {
     private final BoardCommentService boardCommentService;
 
     @PostMapping("/{boardId}/comments")
-    public SuccessResponse<CommentResponse> addComment(@PathVariable Long boardId,
-                                                       @Valid @RequestBody CommentRequest request,
-                                                       @AuthenticationPrincipal Long userId){
+    public SuccessResponse<CommentResponse> addComment(
+            @PathVariable Long boardId,
+            @Valid @RequestBody CommentRequest request,
+            @AuthenticationPrincipal Long userId){
         CommentResponse response = boardCommentService.addComment(request,boardId,userId);
         return ResponseUtil.success(response);
     }
 
     @GetMapping("/comments/{commentId}")
-    public SuccessResponse<CommentResponse> readOneComment(@PathVariable Long commentId,
-                                                           @AuthenticationPrincipal Long userId){
+    public SuccessResponse<CommentResponse> readOneComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal Long userId){
         CommentResponse response = boardCommentService.readOneComment(commentId,userId);
         return ResponseUtil.success(response);
     }
 
     @GetMapping("/{boardId}/comments")
-    public SuccessResponse<List<CommentResponse>> readAllComment(@PathVariable Long boardId,
-                                                                 @AuthenticationPrincipal Long userId){
+    public SuccessResponse<List<CommentResponse>> readAllComment(
+            @PathVariable Long boardId,
+            @AuthenticationPrincipal Long userId){
         List<CommentResponse> response = boardCommentService.readAllComment(boardId,userId);
         return ResponseUtil.success(response);
     }
 
     @PatchMapping("/comments/{commentId}")
-    public SuccessResponse<CommentResponse> updateComment(@PathVariable Long commentId,
-                                                          @RequestBody CommentRequest request,
-                                                          @AuthenticationPrincipal Long userId){
+    public SuccessResponse<CommentResponse> updateComment(
+            @PathVariable Long commentId,
+            @RequestBody CommentRequest request,
+            @AuthenticationPrincipal Long userId){
         CommentResponse response = boardCommentService.updateComment(request,commentId,userId);
         return ResponseUtil.success(response);
     }
 
     @DeleteMapping("/comments/{commentId}")
-    public SuccessResponse<?> deleteComment(@PathVariable Long commentId,
-                                            @AuthenticationPrincipal Long userId){
+    public SuccessResponse<?> deleteComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal Long userId){
         boardCommentService.deleteComment(commentId,userId);
         return ResponseUtil.success();
     }

--- a/src/main/java/com/oinzo/somoim/controller/dto/CommentRequest.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/CommentRequest.java
@@ -1,0 +1,15 @@
+package com.oinzo.somoim.controller.dto;
+
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentRequest {
+
+    @NotBlank
+    private String comment;
+}

--- a/src/main/java/com/oinzo/somoim/controller/dto/CommentResponse.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/CommentResponse.java
@@ -6,6 +6,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -17,6 +20,9 @@ public class CommentResponse {
     private String comment;
     private String userName;
     private String profileImg;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
 
     public static CommentResponse from(BoardComment comment, User user){
         return CommentResponse.builder()
@@ -26,6 +32,8 @@ public class CommentResponse {
                 .comment(comment.getComment())
                 .userName(user.getName())
                 .profileImg(user.getProfileUrl())
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/oinzo/somoim/controller/dto/CommentResponse.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/CommentResponse.java
@@ -1,0 +1,31 @@
+package com.oinzo.somoim.controller.dto;
+
+import com.oinzo.somoim.domain.boardcomment.entity.BoardComment;
+import com.oinzo.somoim.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CommentResponse {
+
+    private Long id;
+    private Long boardId;
+    private Long userId;
+    private String comment;
+    private String userName;
+    private String profileImg;
+
+    public static CommentResponse from(BoardComment comment, User user){
+        return CommentResponse.builder()
+                .id(comment.getId())
+                .boardId(comment.getBoard().getId())
+                .userId(comment.getUser().getId())
+                .comment(comment.getComment())
+                .userName(user.getName())
+                .profileImg(user.getProfileUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/oinzo/somoim/controller/dto/CommentResponse.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/CommentResponse.java
@@ -27,7 +27,7 @@ public class CommentResponse {
     public static CommentResponse from(BoardComment comment, User user){
         return CommentResponse.builder()
                 .id(comment.getId())
-                .boardId(comment.getBoardId())
+                .boardId(comment.getBoard().getId())
                 .userId(comment.getUser().getId())
                 .comment(comment.getComment())
                 .userName(user.getName())

--- a/src/main/java/com/oinzo/somoim/controller/dto/CommentResponse.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/CommentResponse.java
@@ -27,7 +27,7 @@ public class CommentResponse {
     public static CommentResponse from(BoardComment comment, User user){
         return CommentResponse.builder()
                 .id(comment.getId())
-                .boardId(comment.getBoard().getId())
+                .boardId(comment.getBoardId())
                 .userId(comment.getUser().getId())
                 .comment(comment.getComment())
                 .userName(user.getName())

--- a/src/main/java/com/oinzo/somoim/domain/boardcomment/entity/BoardComment.java
+++ b/src/main/java/com/oinzo/somoim/domain/boardcomment/entity/BoardComment.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 @Getter
 @NoArgsConstructor
@@ -26,17 +27,17 @@ public class BoardComment extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn
     private User user;
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn
-    private ClubBoard board;
+
+    @NotNull
+    private Long boardId;
 
     @NotBlank
     private String comment;
 
-    public static BoardComment from(CommentRequest request, ClubBoard board, User user){
+    public static BoardComment from(CommentRequest request, Long boardId, User user){
         return BoardComment.builder()
                 .user(user)
-                .board(board)
+                .boardId(boardId)
                 .comment(request.getComment())
                 .build();
     }

--- a/src/main/java/com/oinzo/somoim/domain/boardcomment/entity/BoardComment.java
+++ b/src/main/java/com/oinzo/somoim/domain/boardcomment/entity/BoardComment.java
@@ -1,0 +1,46 @@
+package com.oinzo.somoim.domain.boardcomment.entity;
+
+import com.oinzo.somoim.common.entity.BaseEntity;
+import com.oinzo.somoim.controller.dto.CommentRequest;
+import com.oinzo.somoim.domain.board.entity.ClubBoard;
+import com.oinzo.somoim.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Builder
+public class BoardComment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private ClubBoard board;
+
+    @NotBlank
+    private String comment;
+
+    public static BoardComment from(CommentRequest request, ClubBoard board, User user){
+        return BoardComment.builder()
+                .user(user)
+                .board(board)
+                .comment(request.getComment())
+                .build();
+    }
+    public void updateComment(CommentRequest request){
+        this.comment = request.getComment();
+    }
+}

--- a/src/main/java/com/oinzo/somoim/domain/boardcomment/entity/BoardComment.java
+++ b/src/main/java/com/oinzo/somoim/domain/boardcomment/entity/BoardComment.java
@@ -28,16 +28,16 @@ public class BoardComment extends BaseEntity {
     @JoinColumn
     private User user;
 
-    @NotNull
-    private Long boardId;
+    @ManyToOne
+    private ClubBoard board;
 
     @NotBlank
     private String comment;
 
-    public static BoardComment from(CommentRequest request, Long boardId, User user){
+    public static BoardComment from(CommentRequest request, ClubBoard board, User user){
         return BoardComment.builder()
                 .user(user)
-                .boardId(boardId)
+                .board(board)
                 .comment(request.getComment())
                 .build();
     }

--- a/src/main/java/com/oinzo/somoim/domain/boardcomment/repository/BoardCommentRepository.java
+++ b/src/main/java/com/oinzo/somoim/domain/boardcomment/repository/BoardCommentRepository.java
@@ -1,0 +1,11 @@
+package com.oinzo.somoim.domain.boardcomment.repository;
+
+import com.oinzo.somoim.domain.boardcomment.entity.BoardComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BoardCommentRepository extends JpaRepository<BoardComment,Long> {
+
+    List<BoardComment> findAllByBoardId(Long boardId);
+}

--- a/src/main/java/com/oinzo/somoim/domain/boardcomment/service/BoardCommentService.java
+++ b/src/main/java/com/oinzo/somoim/domain/boardcomment/service/BoardCommentService.java
@@ -35,7 +35,7 @@ public class BoardCommentService {
         	.orElseThrow(()-> new BaseException(ErrorCode.WRONG_BOARD));
         if (!clubUserRepository.existsByUser_IdAndClub_Id(userId,board.getClub().getId()))
         	throw new BaseException(ErrorCode.NOT_CLUB_MEMBER);
-        BoardComment comment = BoardComment.from(request, boardId, user);
+        BoardComment comment = BoardComment.from(request, board, user);
         comment = boardCommentRepository.save(comment);
         return CommentResponse.from(comment, user);
     }
@@ -45,9 +45,7 @@ public class BoardCommentService {
         	.orElseThrow(()-> new BaseException(ErrorCode.USER_NOT_FOUND));
         BoardComment comment = boardCommentRepository.findById(commentId)
         	.orElseThrow(()-> new BaseException(ErrorCode.WRONG_COMMENT));
-        ClubBoard clubBoard = clubBoardRepository.findById(comment.getBoardId())
-        	.orElseThrow(()-> new BaseException(ErrorCode.WRONG_BOARD,"게시글 조회에 실패하였습니다."));
-        if (!clubUserRepository.existsByUser_IdAndClub_Id(userId,clubBoard.getClub().getId())) {
+        if (!clubUserRepository.existsByUser_IdAndClub_Id(userId,comment.getBoard().getClub().getId())) {
         	throw new BaseException(ErrorCode.NOT_CLUB_MEMBER);
         }
         return CommentResponse.from(comment,user);
@@ -75,7 +73,7 @@ public class BoardCommentService {
         	.orElseThrow(()-> new BaseException(ErrorCode.USER_NOT_FOUND));
         BoardComment comment = boardCommentRepository.findById(commentId)
         	.orElseThrow(()-> new BaseException(ErrorCode.WRONG_COMMENT));
-        ClubBoard board = clubBoardRepository.findById(comment.getBoardId())
+        ClubBoard board = clubBoardRepository.findById(comment.getBoard().getId())
         	.orElseThrow(()-> new BaseException(ErrorCode.WRONG_BOARD));
         if(!clubUserRepository.existsByUser_IdAndClub_Id(userId,board.getClub().getId()))
         	throw new BaseException(ErrorCode.NOT_CLUB_MEMBER);

--- a/src/main/java/com/oinzo/somoim/domain/boardcomment/service/BoardCommentService.java
+++ b/src/main/java/com/oinzo/somoim/domain/boardcomment/service/BoardCommentService.java
@@ -1,0 +1,85 @@
+package com.oinzo.somoim.domain.boardcomment.service;
+
+import com.oinzo.somoim.common.exception.BaseException;
+import com.oinzo.somoim.common.exception.ErrorCode;
+import com.oinzo.somoim.controller.dto.CommentRequest;
+import com.oinzo.somoim.controller.dto.CommentResponse;
+import com.oinzo.somoim.domain.board.entity.ClubBoard;
+import com.oinzo.somoim.domain.board.repository.ClubBoardRepository;
+import com.oinzo.somoim.domain.boardcomment.entity.BoardComment;
+import com.oinzo.somoim.domain.boardcomment.repository.BoardCommentRepository;
+import com.oinzo.somoim.domain.clubuser.repository.ClubUserRepository;
+import com.oinzo.somoim.domain.user.entity.User;
+import com.oinzo.somoim.domain.user.repository.UserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@AllArgsConstructor
+public class BoardCommentService {
+    private final ClubBoardRepository clubBoardRepository;
+    private final UserRepository userRepository;
+    private final BoardCommentRepository boardCommentRepository;
+    private final ClubUserRepository clubUserRepository;
+
+    public CommentResponse addComment(CommentRequest request, Long boardId, Long userId){
+        User user = userRepository.findById(userId).orElseThrow(()-> new BaseException(ErrorCode.USER_NOT_FOUND));
+        ClubBoard board = clubBoardRepository.findById(boardId).orElseThrow(()-> new BaseException(ErrorCode.WRONG_BOARD));
+        if (!clubUserRepository.existsByUser_IdAndClub_Id(userId,board.getClub().getId())) throw new BaseException(ErrorCode.NOT_CLUB_MEMBER);
+        return CommentResponse.from(boardCommentRepository.save(BoardComment.from(request,board,user)),user);
+    }
+
+    public CommentResponse readOneComment(Long commentId,Long userId){
+        User user = userRepository.findById(userId).orElseThrow(()-> new BaseException(ErrorCode.USER_NOT_FOUND));
+        BoardComment comment = boardCommentRepository.findById(commentId).orElseThrow(()-> new BaseException(ErrorCode.WRONG_COMMENT));
+        ClubBoard clubBoard = clubBoardRepository.findById(comment.getBoard().getId())
+                .orElseThrow(()-> new BaseException(ErrorCode.WRONG_BOARD,"게시글 조회에 실패하였습니다."));
+        if (!clubUserRepository.existsByUser_IdAndClub_Id(userId,clubBoard.getClub().getId())) {
+            throw new BaseException(ErrorCode.NOT_CLUB_MEMBER);
+        }
+        return CommentResponse.from(boardCommentRepository.findById(commentId).orElseThrow(()-> new BaseException(ErrorCode.WRONG_COMMENT)),user);
+    }
+
+    public List<CommentResponse> readAllComment(Long boardId, Long userId){
+        if(!userRepository.existsById(userId)) throw new BaseException(ErrorCode.USER_NOT_FOUND);
+        ClubBoard board = clubBoardRepository.findById(boardId).orElseThrow(()-> new BaseException(ErrorCode.WRONG_BOARD));
+        if (!clubUserRepository.existsByUser_IdAndClub_Id(userId,board.getClub().getId())) {
+            throw new BaseException(ErrorCode.NOT_CLUB_MEMBER);
+        }
+        List<BoardComment> resultList = boardCommentRepository.findAllByBoardId(board.getId());
+        List<CommentResponse> result = new ArrayList<>();
+
+        for (BoardComment comment : resultList) {
+            User userInfo = userRepository.findById(comment.getUser().getId())
+                    .orElseThrow(()-> new BaseException(ErrorCode.USER_NOT_FOUND,"댓글의 유저정보 조회에 실패하였습니다."));
+            result.add(CommentResponse.from(comment, userInfo));
+        }
+        return result;
+    }
+
+    @Transactional
+    public CommentResponse updateComment(CommentRequest request, Long commentId, Long userId){
+        User user = userRepository.findById(userId).orElseThrow(()-> new BaseException(ErrorCode.USER_NOT_FOUND));
+        BoardComment comment = boardCommentRepository.findById(commentId).orElseThrow(()-> new BaseException(ErrorCode.WRONG_COMMENT));
+        if(!clubUserRepository.existsByUser_IdAndClub_Id(userId,comment.getBoard().getClub().getId())) throw new BaseException(ErrorCode.NOT_CLUB_MEMBER);
+        if(!Objects.equals(userId, comment.getUser().getId())) throw new BaseException(ErrorCode.FORBIDDEN_REQUEST,"작성자가 아닙니다.");
+        comment.updateComment(request);
+        return CommentResponse.from(boardCommentRepository.save(comment),user);
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId, Long userId){
+        if (!userRepository.existsById(userId)) {
+            throw new BaseException(ErrorCode.USER_NOT_FOUND);
+        }
+        BoardComment comment = boardCommentRepository.findById(commentId).orElseThrow(()-> new BaseException(ErrorCode.WRONG_COMMENT));
+        if(!clubUserRepository.existsByUser_IdAndClub_Id(userId,comment.getBoard().getClub().getId())) throw new BaseException(ErrorCode.NOT_CLUB_MEMBER);
+        if(!Objects.equals(userId, comment.getUser().getId())) throw new BaseException(ErrorCode.FORBIDDEN_REQUEST,"작성자가 아닙니다.");
+        boardCommentRepository.delete(comment);
+    }
+}

--- a/src/test/java/com/oinzo/somoim/domain/boardcomment/service/BoardCommentServiceTest.java
+++ b/src/test/java/com/oinzo/somoim/domain/boardcomment/service/BoardCommentServiceTest.java
@@ -132,7 +132,7 @@ class BoardCommentServiceTest {
         BoardComment comment = BoardComment.builder()
                 .id(1L)
                 .user(mockUser)
-                .boardId(1L)
+                .board(mockBoard)
                 .comment("테스트 댓글")
                 .build();
         given(userRepository.findById(anyLong()))
@@ -183,14 +183,14 @@ class BoardCommentServiceTest {
                 .build();
         BoardComment comment = BoardComment.builder()
                 .user(mockUser)
-                .boardId(1L)
+                .board(mockBoard)
                 .comment("테스트 댓글").build();
         given(userRepository.findById(anyLong()))
                 .willReturn(Optional.of(mockUser));
-        given(boardRepository.findById(anyLong()))
-                .willReturn(Optional.of(mockBoard));
         given(clubUserRepository.existsByUser_IdAndClub_Id(anyLong(),anyLong()))
                 .willReturn(true);
+        given(boardRepository.findById(anyLong()))
+                .willReturn(Optional.of(mockBoard));
         when(commentRepository.save(any(BoardComment.class)))
                 .then(AdditionalAnswers.returnsFirstArg());
         given(commentRepository.findById(anyLong()))

--- a/src/test/java/com/oinzo/somoim/domain/boardcomment/service/BoardCommentServiceTest.java
+++ b/src/test/java/com/oinzo/somoim/domain/boardcomment/service/BoardCommentServiceTest.java
@@ -1,0 +1,208 @@
+package com.oinzo.somoim.domain.boardcomment.service;
+
+import com.oinzo.somoim.common.type.Category;
+import com.oinzo.somoim.common.type.Favorite;
+import com.oinzo.somoim.common.type.Gender;
+import com.oinzo.somoim.controller.dto.CommentRequest;
+import com.oinzo.somoim.controller.dto.CommentResponse;
+import com.oinzo.somoim.domain.board.entity.ClubBoard;
+import com.oinzo.somoim.domain.board.repository.ClubBoardRepository;
+import com.oinzo.somoim.domain.boardcomment.entity.BoardComment;
+import com.oinzo.somoim.domain.boardcomment.repository.BoardCommentRepository;
+import com.oinzo.somoim.domain.club.entity.Club;
+import com.oinzo.somoim.domain.clubuser.repository.ClubUserRepository;
+import com.oinzo.somoim.domain.user.entity.User;
+import com.oinzo.somoim.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalAnswers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class BoardCommentServiceTest {
+
+    @InjectMocks
+    private BoardCommentService commentService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private BoardCommentRepository commentRepository;
+    @Mock
+    private ClubBoardRepository boardRepository;
+    @Mock
+    private ClubUserRepository clubUserRepository;
+
+    @Test
+    void addComment() {
+        // given
+        User mockUser = User.builder()
+                .id(1L)
+                .name("테스트")
+                .birth(LocalDate.parse("2023-03-28"))
+                .gender(Gender.MALE)
+                .area("서울")
+                .introduction("테스트")
+                .favorite(Favorite.GAME)
+                .build();
+        Club mockClub = Club.builder()
+                .id(1L)
+                .name("테스트 클럽")
+                .description("테스트 클럽입니다.")
+                .area("서울")
+                .memberLimit(1)
+                .memberCnt(0)
+                .favorite(Favorite.GAME)
+                .build();
+        ClubBoard mockBoard = ClubBoard.builder()
+                .id(1L)
+                .user(mockUser)
+                .club(mockClub)
+                .category(Category.자유)
+                .title("테스트")
+                .content("테스트 게시판")
+                .imageUrl("URL")
+                .build();
+        given(userRepository.findById(anyLong()))
+                .willReturn(Optional.of(mockUser));
+        given(boardRepository.findById(anyLong()))
+                .willReturn(Optional.of(mockBoard));
+        given(clubUserRepository.existsByUser_IdAndClub_Id(anyLong(),anyLong()))
+                .willReturn(true);
+        when(commentRepository.save(any(BoardComment.class)))
+                .then(AdditionalAnswers.returnsFirstArg());
+
+        ArgumentCaptor<BoardComment> captor = ArgumentCaptor.forClass(BoardComment.class);
+
+        // when
+        CommentRequest request = CommentRequest.builder()
+                .comment("테스트 댓글")
+                .build();
+        commentService.addComment(request,1L,1L);
+
+        // then
+        verify(commentRepository,times(1)).save(captor.capture());
+        assertEquals("테스트 댓글",captor.getValue().getComment());
+    }
+
+    @Test
+    void readOneComment() {
+        // given
+        User mockUser = User.builder()
+                .id(1L)
+                .name("테스트")
+                .birth(LocalDate.parse("2023-03-28"))
+                .gender(Gender.MALE)
+                .area("서울")
+                .introduction("테스트")
+                .favorite(Favorite.GAME)
+                .build();
+        Club mockClub = Club.builder()
+                .id(1L)
+                .name("테스트 클럽")
+                .description("테스트 클럽입니다.")
+                .area("서울")
+                .memberLimit(1)
+                .memberCnt(0)
+                .favorite(Favorite.GAME)
+                .build();
+        ClubBoard mockBoard = ClubBoard.builder()
+                .id(1L)
+                .user(mockUser)
+                .club(mockClub)
+                .category(Category.자유)
+                .title("테스트")
+                .content("테스트 게시판")
+                .imageUrl("URL")
+                .build();
+        BoardComment comment = BoardComment.builder()
+                .id(1L)
+                .user(mockUser)
+                .board(mockBoard)
+                .comment("테스트 댓글")
+                .build();
+        given(userRepository.findById(anyLong()))
+                .willReturn(Optional.of(mockUser));
+        given(boardRepository.findById(anyLong()))
+                .willReturn(Optional.of(mockBoard));
+        given(commentRepository.findById(anyLong()))
+                .willReturn(Optional.of(comment));
+        given(clubUserRepository.existsByUser_IdAndClub_Id(anyLong(),anyLong()))
+                .willReturn(true);
+
+        // when
+        CommentResponse response = commentService.readOneComment(1L,1L);
+
+        // then
+        assertEquals("테스트 댓글",response.getComment());
+    }
+
+    @Test
+    void updateComment() {
+        // given
+        User mockUser = User.builder()
+                .id(1L)
+                .name("테스트")
+                .birth(LocalDate.parse("2023-03-28"))
+                .gender(Gender.MALE)
+                .area("서울")
+                .introduction("테스트")
+                .favorite(Favorite.GAME)
+                .build();
+        Club mockClub = Club.builder()
+                .id(1L)
+                .name("테스트 클럽")
+                .description("테스트 클럽입니다.")
+                .area("서울")
+                .memberLimit(1)
+                .memberCnt(0)
+                .favorite(Favorite.GAME)
+                .build();
+        ClubBoard mockBoard = ClubBoard.builder()
+                .id(1L)
+                .user(mockUser)
+                .club(mockClub)
+                .category(Category.자유)
+                .title("테스트")
+                .content("테스트 게시판")
+                .imageUrl("URL")
+                .build();
+        BoardComment comment = BoardComment.builder()
+                .user(mockUser)
+                .board(mockBoard)
+                .comment("테스트 댓글").build();
+        given(userRepository.findById(anyLong()))
+                .willReturn(Optional.of(mockUser));
+        given(clubUserRepository.existsByUser_IdAndClub_Id(anyLong(),anyLong()))
+                .willReturn(true);
+        when(commentRepository.save(any(BoardComment.class)))
+                .then(AdditionalAnswers.returnsFirstArg());
+        given(commentRepository.findById(anyLong()))
+                .willReturn(Optional.of(comment));
+        ArgumentCaptor<BoardComment> captor = ArgumentCaptor.forClass(BoardComment.class);
+
+        // when
+        CommentRequest request = CommentRequest.builder()
+                .comment("테스트 댓글2")
+                .build();
+        commentService.updateComment(request,1L,1L);
+
+        // then
+        verify(commentRepository,times(1)).save(captor.capture());
+        assertEquals("테스트 댓글2",captor.getValue().getComment());
+    }
+}

--- a/src/test/java/com/oinzo/somoim/domain/boardcomment/service/BoardCommentServiceTest.java
+++ b/src/test/java/com/oinzo/somoim/domain/boardcomment/service/BoardCommentServiceTest.java
@@ -72,7 +72,7 @@ class BoardCommentServiceTest {
                 .id(1L)
                 .user(mockUser)
                 .club(mockClub)
-                .category(Category.자유)
+                .category(Category.FREE)
                 .title("테스트")
                 .content("테스트 게시판")
                 .imageUrl("URL")
@@ -124,7 +124,7 @@ class BoardCommentServiceTest {
                 .id(1L)
                 .user(mockUser)
                 .club(mockClub)
-                .category(Category.자유)
+                .category(Category.FREE)
                 .title("테스트")
                 .content("테스트 게시판")
                 .imageUrl("URL")
@@ -132,7 +132,7 @@ class BoardCommentServiceTest {
         BoardComment comment = BoardComment.builder()
                 .id(1L)
                 .user(mockUser)
-                .board(mockBoard)
+                .boardId(1L)
                 .comment("테스트 댓글")
                 .build();
         given(userRepository.findById(anyLong()))
@@ -176,17 +176,19 @@ class BoardCommentServiceTest {
                 .id(1L)
                 .user(mockUser)
                 .club(mockClub)
-                .category(Category.자유)
+                .category(Category.FREE)
                 .title("테스트")
                 .content("테스트 게시판")
                 .imageUrl("URL")
                 .build();
         BoardComment comment = BoardComment.builder()
                 .user(mockUser)
-                .board(mockBoard)
+                .boardId(1L)
                 .comment("테스트 댓글").build();
         given(userRepository.findById(anyLong()))
                 .willReturn(Optional.of(mockUser));
+        given(boardRepository.findById(anyLong()))
+                .willReturn(Optional.of(mockBoard));
         given(clubUserRepository.existsByUser_IdAndClub_Id(anyLong(),anyLong()))
                 .willReturn(true);
         when(commentRepository.save(any(BoardComment.class)))


### PR DESCRIPTION
## 구현 내용
게시판 댓글 기능입니다.
댓글을 확인하려면 클럽에 가입되어 있어야 하는 것으로 확인되어
모든 api는 클럽에 가입된 멤버만 가능하도록 하였습니다.

<br>

## 관련 이슈
- #40 
<br>

## 중점적으로 봐줬으면 하는 부분
댓글 조회 결과 반환시에 유저 이름과 프로필 이미지가 필요할 것 같아서 추가하였습니다.
때문에 댓글 전체 조회 시 for문을 돌면서 조회 결과 값에 유저 정보를 추가하도록 구성하였는데,
다른 더 좋은 방법이 있거나 수정할 부분이 있는지 확인해주시면 감사할것 같습니다!
