### PR TITLE
fix: 회원정보 조회 API Response에 userId 파라미터 추가 (#49)

### DIFF
--- a/src/main/java/com/oinzo/somoim/controller/dto/UserInfoResponse.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/UserInfoResponse.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class UserInfoResponse {
 
+	private long id;
 	private String name;
 	private LocalDate birth;
 	private Gender gender;
@@ -23,6 +24,7 @@ public class UserInfoResponse {
 
 	public static UserInfoResponse from(User user) {
 		return UserInfoResponse.builder()
+			.id(user.getId())
 			.name(user.getName())
 			.birth(user.getBirth())
 			.gender(user.getGender())

--- a/src/test/java/com/oinzo/somoim/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/oinzo/somoim/domain/user/service/UserServiceTest.java
@@ -54,6 +54,7 @@ class UserServiceTest {
 		UserInfoResponse response = userService.readUserInfo(1L);
 
 		// then
+		assertEquals(1L, response.getId());
 		assertEquals("홍길동", response.getName());
 		assertEquals("2000-01-01", response.getBirth().toString());
 		assertEquals("MALE", response.getGender().name());


### PR DESCRIPTION
## 구현 내용
프론트에서 로그인한 사용자의 userId를 받아볼 수 있도록 회원정보 조회 API의 응답 데이터에 userId를 추가했습니다.
<br>

## 관련 이슈
- #49
