### PR TITLE
Fix/51 club manager

### DIFF
--- a/src/main/java/com/oinzo/somoim/controller/ClubController.java
+++ b/src/main/java/com/oinzo/somoim/controller/ClubController.java
@@ -1,6 +1,7 @@
 package com.oinzo.somoim.controller;
 
 import com.oinzo.somoim.controller.dto.ClubCreateRequest;
+import com.oinzo.somoim.controller.dto.ClubDetailResponse;
 import com.oinzo.somoim.controller.dto.ClubResponse;
 import com.oinzo.somoim.common.response.ResponseUtil;
 import com.oinzo.somoim.common.response.SuccessResponse;
@@ -24,10 +25,10 @@ public class ClubController {
     private final ClubService clubService;
 
     @PostMapping
-    public SuccessResponse<ClubResponse> addClub(
+    public SuccessResponse<ClubDetailResponse> addClub(
         @AuthenticationPrincipal Long userId,
         @RequestBody @Valid ClubCreateRequest request) {
-        ClubResponse club = clubService.addClub(userId, request);
+        ClubDetailResponse club = clubService.addClub(userId, request);
         return ResponseUtil.success(club);
     }
     
@@ -46,11 +47,11 @@ public class ClubController {
     }
 
     @GetMapping("/{clubId}")
-    public SuccessResponse<ClubResponse> readClubById(
+    public SuccessResponse<ClubDetailResponse> readClubById(
         @PathVariable("clubId") Long clubId,
         HttpServletResponse response,
         @CookieValue(value="count", required=false) Cookie countCookie) {
-        ClubResponse club = clubService.readClubById(clubId, response, countCookie);
+        ClubDetailResponse club = clubService.readClubById(clubId, response, countCookie);
         return ResponseUtil.success(club);
     }
     

--- a/src/main/java/com/oinzo/somoim/controller/dto/ClubDetailResponse.java
+++ b/src/main/java/com/oinzo/somoim/controller/dto/ClubDetailResponse.java
@@ -1,0 +1,38 @@
+package com.oinzo.somoim.controller.dto;
+
+import com.oinzo.somoim.common.type.Favorite;
+import com.oinzo.somoim.domain.club.entity.Club;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ClubDetailResponse {
+
+	private Long id;
+	private String name;
+	private String description;
+	private String imageUrl;
+	private String area;
+	private int memberLimit;
+	private int memberCnt;
+	private Favorite favorite;
+	private Long managerId;
+
+	public static ClubDetailResponse fromClubAndManagerId(Club club, Long ManagerId){
+		return ClubDetailResponse.builder()
+			.id(club.getId())
+			.name(club.getName())
+			.description(club.getDescription())
+			.imageUrl(club.getImageUrl())
+			.area(club.getArea())
+			.memberLimit(club.getMemberLimit())
+			.memberCnt(club.getMemberCnt())
+			.favorite(club.getFavorite())
+			.managerId(builder().managerId)
+			.build();
+	}
+
+}

--- a/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
+++ b/src/main/java/com/oinzo/somoim/domain/club/service/ClubService.java
@@ -32,10 +32,10 @@ public class ClubService {
         Club club = Club.from(request);
         Club savedClub = clubRepository.save(club);
 
-        // 클럽 멤버로 등록
+        // 클럽 매니저로 등록
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND, "userId=" + userId));
-        ClubUser clubUser = ClubUser.createClubUser(user, club);
+        ClubUser clubUser = ClubUser.createClubUserManager(user, club);
 
         clubUserRepository.save(clubUser);
 

--- a/src/main/java/com/oinzo/somoim/domain/clubuser/entity/ClubUser.java
+++ b/src/main/java/com/oinzo/somoim/domain/clubuser/entity/ClubUser.java
@@ -39,7 +39,17 @@ public class ClubUser extends BaseEntity {
 	@JoinColumn
 	private Club club;
 
-	public static ClubUser createClubUser(User user, Club club) {
+	public static ClubUser createClubUserManager(User user, Club club) {
+		club.plusMemberCnt();
+
+		return ClubUser.builder()
+			.level(ClubUserLevel.MANAGER)
+			.user(user)
+			.club(club)
+			.build();
+	}
+
+	public static ClubUser createClubUserMember(User user, Club club) {
 		club.plusMemberCnt();
 
 		return ClubUser.builder()

--- a/src/main/java/com/oinzo/somoim/domain/clubuser/repository/ClubUserRepository.java
+++ b/src/main/java/com/oinzo/somoim/domain/clubuser/repository/ClubUserRepository.java
@@ -1,5 +1,6 @@
 package com.oinzo.somoim.domain.clubuser.repository;
 
+import com.oinzo.somoim.common.type.ClubUserLevel;
 import com.oinzo.somoim.domain.clubuser.entity.ClubUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,5 +9,7 @@ import org.springframework.stereotype.Repository;
 public interface ClubUserRepository extends JpaRepository<ClubUser, Long> {
 
 	Boolean existsByUser_IdAndClub_Id(Long userId, Long clubId);
+
+	ClubUser findByClub_IdAndLevel(Long clubId, ClubUserLevel level);
 
 }

--- a/src/main/java/com/oinzo/somoim/domain/clubuser/service/ClubUserService.java
+++ b/src/main/java/com/oinzo/somoim/domain/clubuser/service/ClubUserService.java
@@ -41,7 +41,7 @@ public class ClubUserService {
 		// 클럽 멤버로 등록
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND, "userId=" + userId));
-		ClubUser clubUser = ClubUser.createClubUser(user, club);
+		ClubUser clubUser = ClubUser.createClubUserMember(user, club);
 		clubUserRepository.save(clubUser);
 	}
 }

--- a/src/main/java/com/oinzo/somoim/domain/clubuser/service/ClubUserService.java
+++ b/src/main/java/com/oinzo/somoim/domain/clubuser/service/ClubUserService.java
@@ -2,6 +2,7 @@ package com.oinzo.somoim.domain.clubuser.service;
 
 import com.oinzo.somoim.common.exception.BaseException;
 import com.oinzo.somoim.common.exception.ErrorCode;
+import com.oinzo.somoim.common.type.ClubUserLevel;
 import com.oinzo.somoim.domain.club.entity.Club;
 import com.oinzo.somoim.domain.club.repository.ClubRepository;
 import com.oinzo.somoim.domain.clubuser.entity.ClubUser;
@@ -43,5 +44,10 @@ public class ClubUserService {
 			.orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND, "userId=" + userId));
 		ClubUser clubUser = ClubUser.createClubUserMember(user, club);
 		clubUserRepository.save(clubUser);
+	}
+
+	public Long getClubManagerId(long clubId) {
+		ClubUser managerClubUser = clubUserRepository.findByClub_IdAndLevel(clubId, ClubUserLevel.MANAGER);
+		return managerClubUser.getUser().getId();
 	}
 }

--- a/src/test/java/com/oinzo/somoim/ClubControllerTest.java
+++ b/src/test/java/com/oinzo/somoim/ClubControllerTest.java
@@ -1,6 +1,7 @@
 package com.oinzo.somoim;
 
 import com.oinzo.somoim.controller.dto.ClubCreateRequest;
+import com.oinzo.somoim.controller.dto.ClubDetailResponse;
 import com.oinzo.somoim.controller.dto.ClubResponse;
 import com.oinzo.somoim.domain.club.entity.Club;
 import com.oinzo.somoim.domain.club.repository.ClubRepository;
@@ -30,10 +31,10 @@ class ClubControllerTest {
         /* given */
         ClubCreateRequest newClub = new ClubCreateRequest("새로운 클럽","테스트용 클럽","","서울",3,"GAME");
         /* when */
-        ClubResponse clubResponse = clubService.addClub(7L, newClub);
+        ClubDetailResponse clubDetailResponse = clubService.addClub(7L, newClub);
         /* then */
-        Assertions.assertEquals("새로운 클럽", clubResponse.getName());
-        Assertions.assertEquals(1, clubResponse.getMemberCnt());
+        Assertions.assertEquals("새로운 클럽", clubDetailResponse.getName());
+        Assertions.assertEquals(1, clubDetailResponse.getMemberCnt());
     }
 
     @Test


### PR DESCRIPTION
## 구현 내용
클럽을 생성한 사용자는 멤버 등급을 MANAGER로 되도록 코드를 수정하였습니다.
멤버 목록 조회 API와 자신이 가입한 클럽 목록 조회 API의 Reponse에 멤버 등급을 추가하였습니다.
<br>

## 관련 이슈
- #51
