### PR TITLE
fix: 인증번호 인증 메일의 양식 수정 (#84)

### DIFF
--- a/src/main/java/com/oinzo/somoim/domain/user/service/EmailService.java
+++ b/src/main/java/com/oinzo/somoim/domain/user/service/EmailService.java
@@ -65,12 +65,15 @@ public class EmailService {
 
 		String from = sender;
 		String title = "소모임 회원가입을 위한 인증번호";
+		String text = "<h1>이메일 인증코드</h1>\n"
+			+ "<p>소모임 회원가입을 위해 이메일 인증을 진행합니다.<br>아래의 인증코드를 입력하시면 이메일 인증이 완료됩니다.</p>\n"
+			+ "<p style=\"background: #EFEFEF; font-size: 30px;padding: 10px\">" + code + "</p>";
 
 		MimeMessage message = mailSender.createMimeMessage();
 		message.addRecipients(MimeMessage.RecipientType.TO, email);
 		message.setSubject(title);
 		message.setFrom(from);
-		message.setText(code, "utf-8", "html");
+		message.setText(text, "utf-8", "html");
 
 		return message;
 	}


### PR DESCRIPTION
## 구현 내용
인증 메일의 양식에 서비스 설명을 추가하고 CSS를 수정했습니다.
<br>

## 관련 이슈
- #84

